### PR TITLE
Vertically flipped DXT1 and DXT5 textures to keep original files orienta...

### DIFF
--- a/src/info/ata4/unity/cli/extract/AssetExtractHandler.java
+++ b/src/info/ata4/unity/cli/extract/AssetExtractHandler.java
@@ -74,7 +74,7 @@ public abstract class AssetExtractHandler {
     public void setOutputFileName(String outFileName) {
         // remove any chars that could cause troubles on various file systems
         if (!StringUtils.isBlank(outFileName)) {
-            outFileName = outFileName.replaceAll("[^a-zA-Z0-9\\._]+", "_");
+            outFileName = outFileName.replaceAll("[^a-zA-Z0-9\\._-]+", "_");
         }
         this.outFileName = outFileName;
     }


### PR DESCRIPTION
Hello,

I did a while ago some changes regarding DXTn textures orientation. Apparently (from my tests) the extracted dds files are vertically flipped compared the the original image files used to build theasset bundle. So I added a few lines to flip vertically DXT1 and DXT5 data without decompressing it. 

There is another little thing regarding file names sanitization, I allowed the "-" character as it is a common character in textures file names and replacing it by "_" was breaking textures references in extracted materials (I could fix missing references on my side but I think it is better the not alter too much original file names and as you see it is a very small change.

Bellow are the changes that should interest you.
