### PR TITLE
Have shell script follow symlink

### DIFF
--- a/scripts/disunity.sh
+++ b/scripts/disunity.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-BASEDIR=$(dirname "$0")
+BASEDIR="$( cd "$( dirname "$( readlink -f ${BASH_SOURCE[0]} )" )" && pwd )"
 java -jar "$BASEDIR/disunity.jar" "$@"


### PR DESCRIPTION
This is so a symlink to the script can be placed in a directory such as `/usr/bin` and function correctly.

Assuming that this doesn't break anything on OS X.
