### PR TITLE
Use maven-shade-plugin to create a fat jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,36 +27,23 @@
     </resources>
 
     <plugins>
-      <!-- Take care of MANIFEST.MF -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>2.5</version>
-        <configuration>
-          <archive>
-            <index>true</index>
-            <manifest>
-              <addClasspath>true</addClasspath>
-              <classpathPrefix>lib/</classpathPrefix>
-              <mainClass>info.ata4.disunity.cli.DisUnityCli</mainClass>
-            </manifest>
-          </archive>
-        </configuration>
-      </plugin>
-
-      <!-- Copy dependency .jar files on 'mvn package' -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.9</version>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.3</version>
         <executions>
           <execution>
             <phase>package</phase>
             <goals>
-              <goal>copy-dependencies</goal>
+              <goal>shade</goal>
             </goals>
             <configuration>
-              <outputDirectory>${project.build.directory}/lib</outputDirectory>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>info.ata4.disunity.cli.DisUnityCli</mainClass>
+                </transformer>
+              </transformers>
+              <minimizeJar>true</minimizeJar>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Using a fat jar negates the need to distribute the ./lib folder.  Also,
using minimization on the shaded jar makes the release size smaller.

Unfortunately I wasn't able to test this properly.  When I build master, I nothing except the `list` operation works for me.  When I use the `v0.3.4` release, everything works properly.