### PR TITLE
Add Main-Class configuration for MAINFEST.MF

### DIFF
--- a/disunity-dist/pom.xml
+++ b/disunity-dist/pom.xml
@@ -43,6 +43,13 @@
                         <goals>
                             <goal>shade</goal>
                         </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>info.ata4.disunity.cli.DisUnityCli</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20141113</version>
+            <version>20140107</version>
         </dependency>
 
         <!-- Dependencies from jitpack.io -->


### PR DESCRIPTION
This makes it simple to simply 'mvn install' and automatically generate a dist .jar that's runnable.

(Ran into this issue when attempting to build the 0.4+ version)