### PR TITLE
Change pom.xml to org.json version for Java 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20141113</version>
+            <version>20140107</version>
         </dependency>
 
         <!-- Dependencies from jitpack.io -->


### PR DESCRIPTION
The maven.compiler.source and .target are set to 1.7, so I'm assuming you want v7 compatibility - but org.json 20140107 was the last version with v7 compatbility.