### PR TITLE
Initial unity 5.0 support

### DIFF
--- a/disunity-core/src/main/java/info/ata4/disunity/extract/AudioClipExtractor.java
+++ b/disunity-core/src/main/java/info/ata4/disunity/extract/AudioClipExtractor.java
@@ -55,10 +55,17 @@ public class AudioClipExtractor extends AbstractAssetExtractor {
         return new UnityClass("AudioClip");
     }
     
+        
     @Override
     public void extract(ObjectData objectData) throws IOException {
         AudioClip audio = new AudioClip(objectData.instance());
         String name = audio.getName();
+        
+        if (objectData.instance().getChild("m_Resource") != null) {
+            L.log(Level.WARNING, "Audio clip {0} has external resource, which is not supported by disunity", audio.getName());
+            return;
+        }
+        
         ByteBuffer audioData = audio.getAudioData();
         
         // skip empty buffers

--- a/disunity-core/src/main/java/info/ata4/unity/asset/AssetFile.java
+++ b/disunity-core/src/main/java/info/ata4/unity/asset/AssetFile.java
@@ -195,6 +195,10 @@ public class AssetFile extends FileHandler {
         if (header.version() > 13) {
             in.align(4);
             int num = in.readInt();
+            if (num != 0 && header.version() >= 15) { 
+                // sorry, no info on that block => cant read externals. num -> num-9 worked for my experimental file, but I dont know about others
+                return;
+            } 
             for (int i = 0; i < num; i++) {
                 in.readInt();
                 in.readInt();

--- a/disunity-core/src/main/java/info/ata4/unity/asset/ObjectInfo.java
+++ b/disunity-core/src/main/java/info/ata4/unity/asset/ObjectInfo.java
@@ -48,6 +48,8 @@ public class ObjectInfo extends UnityStruct {
         typeID = in.readInt();
         classID = in.readShort();
         isDestroyed = in.readShort();
+        if (versionInfo.assetVersion()>=15)
+            in.readInt();
 
         assert typeID == classID || (classID == 114 && typeID < 0);
     }


### PR DESCRIPTION
I tested it on creativerse.

Problems:
1) in some cases I cannot determine externals block position
2) AudioClipExtractor doesnt with resources that are contained in separate binary file, linked through "m_Resource" field.