### PR TITLE
Don't repeat class and version mismatch warnings

### DIFF
--- a/disunity-core/src/main/java/info/ata4/unity/assetbundle/AssetBundleUtils.java
+++ b/disunity-core/src/main/java/info/ata4/unity/assetbundle/AssetBundleUtils.java
@@ -88,7 +88,7 @@ public class AssetBundleUtils {
             }
             
             String bundleName = outDir.getFileName().toString();
-            Path propsFile = outDir.getParent().resolve(bundleName + ".json");
+            Path propsFile = outDir.resolveSibling(bundleName + ".json");
             
             writePropertiesFile(propsFile, assetBundle);
         }


### PR DESCRIPTION
to make it easier to wade through all of the warnings I'm getting!

Also a fix for something I was hitting with bundle-extract: if you run disunity from the same directory as the bundle then there's no parent path in a default output dir so the 'getParent().resolve' didn't work.

Thanks! I will look into updating the types.dat too; what would you suggest, e.g. get the Unity Labs demo and all of the standard packages for a specific Unity version and try and import types from that data?