### PR TITLE
Fixed whitespace issues

### DIFF
--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/DisUnityCli.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/DisUnityCli.java
@@ -21,28 +21,28 @@ import java.util.logging.Logger;
 
 /**
  * DisUnity command line interface.
- * 
+ *
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class DisUnityCli {
-    
+
     private static final Logger L = LogUtils.getLogger();
-    
+
     /**
      * @param args the command line arguments
      */
     public static void main(String[] args) {
         LogUtils.configure();
-        
+
         try (PrintWriter out = new PrintWriter(new OutputStreamWriter(System.out), true)) {
             JCommander jc = new JCommander();
-            DisUnityRoot root = new DisUnityRoot();     
+            DisUnityRoot root = new DisUnityRoot();
             root.init(jc, out);
-            
+
             jc.setProgramName(DisUnity.getProgramName());
             jc.addObject(root);
             jc.parse(args);
-            
+
             root.run();
         } catch (ParameterException ex) {
             L.log(Level.WARNING, "Parameter error: {0}", ex.getMessage());

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/OutputFormat.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/OutputFormat.java
@@ -11,7 +11,7 @@ package info.ata4.disunity.cli;
 
 /**
  * CLI text output format enum
- * 
+ *
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public enum OutputFormat {

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/OutputFormatDelegate.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/OutputFormatDelegate.java
@@ -1,11 +1,11 @@
 /*
-** 2015 December 22
-**
-** The author disclaims copyright to this source code. In place of
-** a legal notice, here is a blessing:
-**    May you do good and not evil.
-**    May you find forgiveness for yourself and forgive others.
-**    May you share freely, never taking more than you give.
+ ** 2015 December 22
+ **
+ ** The author disclaims copyright to this source code. In place of
+ ** a legal notice, here is a blessing:
+ **    May you do good and not evil.
+ **    May you find forgiveness for yourself and forgive others.
+ **    May you share freely, never taking more than you give.
  */
 package info.ata4.disunity.cli;
 
@@ -17,13 +17,13 @@ import java.util.function.Supplier;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class OutputFormatDelegate implements Supplier<OutputFormat> {
-    
+
     @Parameter(
         names = { "-f", "--output-format" },
         description = "Set output text format."
     )
     private OutputFormat outputFormat = OutputFormat.TEXT;
-    
+
     @Override
     public OutputFormat get() {
         return outputFormat;

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/command/Command.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/command/Command.java
@@ -24,7 +24,7 @@ public abstract class Command implements Runnable {
 
     private JCommander commander;
     private PrintWriter out;
-    
+
     protected final Progress progress = (s, p) -> {
         if (s.isPresent()) {
             output().println(s.get());
@@ -35,11 +35,11 @@ public abstract class Command implements Runnable {
         this.commander = Objects.requireNonNull(commander);
         this.out = Objects.requireNonNull(out);
     }
-        
+
     public JCommander commander() {
         return commander;
     }
-    
+
     @Override
     public void run() {
         String commandName = commander.getParsedCommand();
@@ -54,19 +54,19 @@ public abstract class Command implements Runnable {
             }
         }
     }
-    
+
     protected JCommander addSubCommand(String commandName, Command commandObj) {
         commander.addCommand(commandName, commandObj);
         JCommander subCommander = commander.getCommands().get(commandName);
         commandObj.init(subCommander, out);
         return subCommander;
     }
-    
+
     protected void usage() {
         output().println(DisUnity.getSignature());
         commander().usage();
     }
-    
+
     protected PrintWriter output() {
         return out;
     }

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/command/DisUnityRoot.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/command/DisUnityRoot.java
@@ -24,14 +24,14 @@ import java.util.logging.Level;
  */
 @Parameters
 public class DisUnityRoot extends Command {
-    
+
     @Parameter(
         names = {"-h", "--help"},
         description = "Print this help.",
         help = true
     )
     private boolean help;
-    
+
     @Parameter(
         names = { "-v", "--verbose" },
         description = "Show more verbose log output."
@@ -41,7 +41,7 @@ public class DisUnityRoot extends Command {
     @Override
     public void init(JCommander commander, PrintWriter out) {
         super.init(commander, out);
-        
+
         addSubCommand("bundle", new BundleRoot());
         addSubCommand("asset", new AssetRoot());
     }
@@ -52,13 +52,13 @@ public class DisUnityRoot extends Command {
         if (verbose) {
             LogUtils.configure(Level.ALL);
         }
-        
+
         // display usage
         if (help) {
             usage();
             return;
         }
-        
+
         super.run();
     }
 }

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/command/FileCommand.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/command/FileCommand.java
@@ -19,18 +19,18 @@ import java.util.List;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public abstract class FileCommand extends Command {
-    
+
     @Parameter(
         description = "<file> [file]...",
         converter = PathConverter.class,
         required = true
     )
     private List<Path> filePaths;
-    
+
     @Override
     public void run() {
         filePaths.forEach(this::runFile);
     }
-    
+
     protected abstract void runFile(Path file);
 }

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/command/RecursiveFileCommand.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/command/RecursiveFileCommand.java
@@ -1,11 +1,11 @@
 /*
-** 2015 December 03
-**
-** The author disclaims copyright to this source code. In place of
-** a legal notice, here is a blessing:
-**    May you do good and not evil.
-**    May you find forgiveness for yourself and forgive others.
-**    May you share freely, never taking more than you give.
+ ** 2015 December 03
+ **
+ ** The author disclaims copyright to this source code. In place of
+ ** a legal notice, here is a blessing:
+ **    May you do good and not evil.
+ **    May you find forgiveness for yourself and forgive others.
+ **    May you share freely, never taking more than you give.
  */
 package info.ata4.disunity.cli.command;
 
@@ -23,15 +23,15 @@ import java.util.logging.Logger;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public abstract class RecursiveFileCommand extends FileCommand {
-    
+
     private static final Logger L = LogUtils.getLogger();
-    
+
     @Parameter(
         names = { "-r", "--recursive" },
         description = "Scan directories and sub-directories for files as well."
     )
     private boolean recursive = defaultRecursive();
-    
+
     @Parameter(
         names = { "-d", "--recursive-depth" },
         description = "The maximum number of directory levels to visit."
@@ -52,17 +52,17 @@ public abstract class RecursiveFileCommand extends FileCommand {
             runFileRecursive(file);
         }
     }
-    
+
     protected abstract void runFileRecursive(Path file);
-    
+
     protected boolean fileFilter(Path file) {
         return Files.isRegularFile(file);
     }
-    
+
     protected boolean defaultRecursive() {
         return false;
     }
-    
+
     protected int defaultMaxDepth() {
         return 1024;
     }

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/command/asset/AssetBlocks.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/command/asset/AssetBlocks.java
@@ -1,11 +1,11 @@
 /*
-** 2015 December 22
-**
-** The author disclaims copyright to this source code. In place of
-** a legal notice, here is a blessing:
-**    May you do good and not evil.
-**    May you find forgiveness for yourself and forgive others.
-**    May you share freely, never taking more than you give.
+ ** 2015 December 22
+ **
+ ** The author disclaims copyright to this source code. In place of
+ ** a legal notice, here is a blessing:
+ **    May you do good and not evil.
+ **    May you find forgiveness for yourself and forgive others.
+ **    May you share freely, never taking more than you give.
  */
 package info.ata4.disunity.cli.command.asset;
 
@@ -27,11 +27,11 @@ import java.util.Map;
     commandDescription = "List file data blocks."
 )
 public class AssetBlocks extends AssetTableCommand {
-    
+
     @Override
     protected TableModel tableModel(SerializedFile serialized) {
         Map<String, DataBlock> blocks = new LinkedHashMap<>();
-        
+
         blocks.put("Header", serialized.headerBlock());
         blocks.put("Type Tree", serialized.metadata().typeTreeBlock());
         blocks.put("Object Info", serialized.metadata().objectInfoBlock());
@@ -40,9 +40,9 @@ public class AssetBlocks extends AssetTableCommand {
 
         TableBuilder table = new TableBuilder();
         table.row("Name", "Offset", "Size");
-        
+
         blocks.entrySet().stream()
-            .sorted((e1, e2) -> 
+            .sorted((e1, e2) ->
                 Long.compare(
                     e1.getValue().offset(),
                     e2.getValue().offset()
@@ -56,7 +56,7 @@ public class AssetBlocks extends AssetTableCommand {
                     block.length()
                 );
             });
-        
+
         TableModel model = new TableModel("Blocks", table.get());
         TextTableFormat format = model.format();
         format.columnFormatter(1, Formatters::hex);

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/command/asset/AssetCommand.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/command/asset/AssetCommand.java
@@ -30,9 +30,9 @@ import java.util.logging.Logger;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public abstract class AssetCommand extends RecursiveFileCommand {
-    
+
     private static final Logger L = LogUtils.getLogger();
-    
+
     @Override
     protected void runFileRecursive(Path file) {
         if (BundleUtils.isBundle(file)) {
@@ -63,6 +63,6 @@ public abstract class AssetCommand extends RecursiveFileCommand {
             }
         }
     }
-    
+
     protected abstract void runSerializedFile(Path file, SerializedFile serialized);
 }

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/command/asset/AssetExternalRefs.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/command/asset/AssetExternalRefs.java
@@ -1,11 +1,11 @@
 /*
-** 2015 December 22
-**
-** The author disclaims copyright to this source code. In place of
-** a legal notice, here is a blessing:
-**    May you do good and not evil.
-**    May you find forgiveness for yourself and forgive others.
-**    May you share freely, never taking more than you give.
+ ** 2015 December 22
+ **
+ ** The author disclaims copyright to this source code. In place of
+ ** a legal notice, here is a blessing:
+ **    May you do good and not evil.
+ **    May you find forgiveness for yourself and forgive others.
+ **    May you share freely, never taking more than you give.
  */
 package info.ata4.disunity.cli.command.asset;
 
@@ -25,34 +25,34 @@ import info.ata4.junity.serialize.fileidentifier.FileIdentifierV2;
     commandDescription = "List external references."
 )
 public class AssetExternalRefs extends AssetTableCommand {
-    
+
     @Override
     protected TableModel tableModel(SerializedFile serialized) {
         FileIdentifierTable<FileIdentifier> externals = serialized.metadata().externals();
         Class<FileIdentifier> factory = externals.elementFactory();
-        
+
         boolean v2 = FileIdentifierV2.class.isAssignableFrom(factory);
-        
+
         TableBuilder table = new TableBuilder();
         table.row("File Path");
-        
+
         if (v2) {
             table.append("Asset Path");
         }
-        
+
         table.append("GUID", "Type");
-        
+
         externals.elements().forEach(external -> {
             table.row(external.filePath());
-            
+
             if (v2) {
                 table.append(((FileIdentifierV2) external).assetPath());
             }
-            
+
             table.append(external.guid(), external.type());
         });
 
         return new TableModel("External References", table.get());
     }
-    
+
 }

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/command/asset/AssetHeader.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/command/asset/AssetHeader.java
@@ -1,11 +1,11 @@
 /*
-** 2015 December 22
-**
-** The author disclaims copyright to this source code. In place of
-** a legal notice, here is a blessing:
-**    May you do good and not evil.
-**    May you find forgiveness for yourself and forgive others.
-**    May you share freely, never taking more than you give.
+ ** 2015 December 22
+ **
+ ** The author disclaims copyright to this source code. In place of
+ ** a legal notice, here is a blessing:
+ **    May you do good and not evil.
+ **    May you find forgiveness for yourself and forgive others.
+ **    May you share freely, never taking more than you give.
  */
 package info.ata4.disunity.cli.command.asset;
 
@@ -27,10 +27,10 @@ public class AssetHeader extends AssetTableCommand {
     @Override
     protected TableModel tableModel(SerializedFile serialized) {
         SerializedFileHeader header = serialized.header();
-        
+
         TableBuilder table = new TableBuilder();
         table.row("Field", "Value");
-        
+
         table.row("metadataSize", header.metadataSize());
         table.row("fileSize", header.fileSize());
         table.row("version", header.version());
@@ -39,8 +39,8 @@ public class AssetHeader extends AssetTableCommand {
         if (header.version() >= 9) {
             table.row("endianness", header.endianness());
         }
-        
+
         return new TableModel("Header", table.get());
     }
-    
+
 }

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/command/asset/AssetObjectIDs.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/command/asset/AssetObjectIDs.java
@@ -1,11 +1,11 @@
 /*
-** 2015 December 22
-**
-** The author disclaims copyright to this source code. In place of
-** a legal notice, here is a blessing:
-**    May you do good and not evil.
-**    May you find forgiveness for yourself and forgive others.
-**    May you share freely, never taking more than you give.
+ ** 2015 December 22
+ **
+ ** The author disclaims copyright to this source code. In place of
+ ** a legal notice, here is a blessing:
+ **    May you do good and not evil.
+ **    May you find forgiveness for yourself and forgive others.
+ **    May you share freely, never taking more than you give.
  */
 package info.ata4.disunity.cli.command.asset;
 
@@ -27,7 +27,7 @@ public class AssetObjectIDs extends AssetTableCommand {
     protected TableModel tableModel(SerializedFile serialized) {
         TableBuilder table = new TableBuilder();
         table.row("Asset Index", "ID in file");
-        
+
         serialized.metadata().objectIDTable().elements().forEach(objectID -> {
             table.row(objectID.serializedFileIndex(), objectID.identifierInFile());
         });

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/command/asset/AssetObjects.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/command/asset/AssetObjects.java
@@ -34,52 +34,52 @@ public class AssetObjects extends AssetTableCommand {
     @Override
     protected TableModel tableModel(SerializedFile serialized) {
         SerializedFileMetadata metadata = serialized.metadata();
-        
+
         TableBuilder table = new TableBuilder();
         table.row("Path ID", "Offset", "Length", "Type ID", "Class ID");
-        
+
         Class<ObjectInfo> factory = metadata.objectInfoTable().elementFactory();
-        
+
         boolean typeTreePresent = metadata.typeTree().embedded();
         boolean v2 = ObjectInfoV2.class.isAssignableFrom(factory);
         boolean v3 = ObjectInfoV3.class.isAssignableFrom(factory);
-        
+
         if (typeTreePresent) {
             table.append("Class Name");
         }
-  
+
         if (v2) {
             table.append("Script Type ID");
         }
-        
+
         if (v3) {
             table.append("Stripped");
         }
-        
+
         metadata.objectInfoTable().infoMap().entrySet().stream().forEach(e -> {
             ObjectInfo info = e.getValue();
             table.row(e.getKey(), info.offset(), info.length(), info.typeID(),
                     info.classID());
-            
+
             if (typeTreePresent) {
                 TypeRoot<Type> baseClass = metadata.typeTree().typeMap().get(info.typeID());
                 String className = baseClass.nodes().data().typeName();
                 table.append(className);
             }
-            
+
             if (v2) {
                 table.append(((ObjectInfoV2) info).scriptTypeIndex());
             }
-            
+
             if (v3) {
                 table.append(((ObjectInfoV3) info).isStripped());
             }
         });
-        
+
         TableModel model = new TableModel("Objects", table.get());
         TextTableFormat format = model.format();
         format.columnFormatter(1, Formatters::hex);
-        
+
         return model;
     }
 }

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/command/asset/AssetRoot.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/command/asset/AssetRoot.java
@@ -24,7 +24,7 @@ public class AssetRoot extends Command {
     @Override
     public void init(JCommander commander, PrintWriter out) {
         super.init(commander, out);
-        
+
         addSubCommand("blocks", new AssetBlocks());
         addSubCommand("externals", new AssetExternalRefs());
         addSubCommand("header", new AssetHeader());

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/command/asset/AssetTableCommand.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/command/asset/AssetTableCommand.java
@@ -1,11 +1,11 @@
 /*
-** 2015 December 22
-**
-** The author disclaims copyright to this source code. In place of
-** a legal notice, here is a blessing:
-**    May you do good and not evil.
-**    May you find forgiveness for yourself and forgive others.
-**    May you share freely, never taking more than you give.
+ ** 2015 December 22
+ **
+ ** The author disclaims copyright to this source code. In place of
+ ** a legal notice, here is a blessing:
+ **    May you do good and not evil.
+ **    May you find forgiveness for yourself and forgive others.
+ **    May you share freely, never taking more than you give.
  */
 package info.ata4.disunity.cli.command.asset;
 
@@ -21,7 +21,7 @@ import java.nio.file.Path;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public abstract class AssetTableCommand extends AssetCommand {
-    
+
     @ParametersDelegate
     private final OutputFormatDelegate outputFormat = new OutputFormatDelegate();
 
@@ -32,6 +32,6 @@ public abstract class AssetTableCommand extends AssetCommand {
         tablePrinter.file(file);
         tablePrinter.print(tableModel(serialized));
     }
-    
+
     protected abstract TableModel tableModel(SerializedFile serialized);
 }

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/command/asset/AssetTypes.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/command/asset/AssetTypes.java
@@ -1,11 +1,11 @@
 /*
-** 2015 December 20
-**
-** The author disclaims copyright to this source code. In place of
-** a legal notice, here is a blessing:
-**    May you do good and not evil.
-**    May you find forgiveness for yourself and forgive others.
-**    May you share freely, never taking more than you give.
+ ** 2015 December 20
+ **
+ ** The author disclaims copyright to this source code. In place of
+ ** a legal notice, here is a blessing:
+ **    May you do good and not evil.
+ **    May you find forgiveness for yourself and forgive others.
+ **    May you share freely, never taking more than you give.
  */
 package info.ata4.disunity.cli.command.asset;
 
@@ -31,39 +31,39 @@ import org.apache.commons.lang3.StringUtils;
     commandDescription = "List embedded runtime types."
 )
 public class AssetTypes extends AssetCommand {
-    
+
     @ParametersDelegate
     private final OutputFormatDelegate outputFormat = new OutputFormatDelegate();
-    
+
     @Override
     protected void runSerializedFile(Path file, SerializedFile serialized) {
         TypeTree<? extends Type> typeTree = serialized.metadata().typeTree();
-        
+
         switch (outputFormat.get()) {
             case JSON:
                 printJson(file, typeTree);
                 break;
-            
+
             default:
                 printText(file, typeTree);
         }
     }
-    
+
     private void printText(Path file, TypeTree<? extends Type> typeTree) {
         output().println(file);
-        
+
         if (!typeTree.embedded()) {
             output().println("File doesn't contain type information");
             return;
         }
-        
+
         typeTree.typeMap().forEach((path, typeRoot) -> {
             output().printf("pathID: %d, classID: %d%n", path, typeRoot.classID());
             printTypeNodeText(typeRoot.nodes(), 0);
             output().println();
         });
     }
-    
+
     private void printTypeNodeText(Node<? extends Type> node, int level) {
         String indent = StringUtils.repeat("  ", level);
         Type type = node.data();
@@ -71,16 +71,16 @@ public class AssetTypes extends AssetCommand {
                 type.typeName(), type.fieldName(), type.metaFlag());
         node.forEach(t -> printTypeNodeText(t, level + 1));
     }
-    
+
     private void printJson(Path file, TypeTree<? extends Type> typeTree) {
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
-        
+
         JsonObject jsonTypeTree = new JsonObject();
         jsonTypeTree.addProperty("file", file.toString());
 
         if (typeTree.embedded()) {
             JsonArray jsonTypes = new JsonArray();
-            
+
             typeTree.typeMap().forEach((path, typeRoot) -> {
                 JsonObject jsonTypeNode = new JsonObject();
                 jsonTypeNode.addProperty("pathID", path);
@@ -96,18 +96,18 @@ public class AssetTypes extends AssetCommand {
 
                 jsonTypes.add(jsonTypeNode);
             });
-            
+
             jsonTypeTree.add("types", jsonTypes);
         }
-        
+
         gson.toJson(jsonTypeTree, output());
     }
-    
+
     private JsonObject typeNodeToJson(Node<? extends Type> node, Gson gson) {
         JsonObject jsonNode = new JsonObject();
-        
+
         jsonNode.add("data", gson.toJsonTree(node.data()));
-        
+
         if (!node.isEmpty()) {
             JsonArray jsonChildren = new JsonArray();
             node.forEach(childNode -> {
@@ -115,7 +115,7 @@ public class AssetTypes extends AssetCommand {
             });
             jsonNode.add("children", jsonChildren);
         }
-        
+
         return jsonNode;
     }
 }

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/command/asset/AssetUnpack.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/command/asset/AssetUnpack.java
@@ -34,9 +34,9 @@ import java.util.logging.Logger;
     commandDescription = "Split asset file into data blocks."
 )
 public class AssetUnpack extends AssetCommand {
-    
+
     private static final Logger L = LogUtils.getLogger();
-    
+
     @Parameter(
         names = {"-l", "--level"},
         description = "Unpacking level"
@@ -51,16 +51,16 @@ public class AssetUnpack extends AssetCommand {
             if (Files.isRegularFile(outputDir)) {
                 outputDir = PathUtils.append(outputDir, "_");
             }
-            
+
             if (Files.notExists(outputDir)) {
                 Files.createDirectory(outputDir);
             }
-            
+
             try (FileChannel fc = FileChannel.open(file)) {
                 DataBlock headerBlock = asset.headerBlock();
                 Path headerFile = outputDir.resolve("header.block");
                 copyBlock(headerBlock, headerFile, fc);
-                
+
                 if (level > 0) {
                     DataBlock typeTreeBlock = asset.metadata().typeTreeBlock();
                     Path typeTreeFile = outputDir.resolve("type_tree.block");
@@ -69,7 +69,7 @@ public class AssetUnpack extends AssetCommand {
                     DataBlock objectInfoBlock = asset.metadata().objectInfoBlock();
                     Path objectInfoFile = outputDir.resolve("object_info.block");
                     copyBlock(objectInfoBlock, objectInfoFile, fc);
-                    
+
                     DataBlock objectIDBlock = asset.metadata().objectIDBlock();
                     if (objectIDBlock.length() > 0) {
                         Path objectIDFile = outputDir.resolve("object_ids.block");
@@ -84,27 +84,27 @@ public class AssetUnpack extends AssetCommand {
                     Path metadataFile = outputDir.resolve("metadata.block");
                     copyBlock(metadataBlock, metadataFile, fc);
                 }
-                
+
                 if (level < 2) {
                     DataBlock objectDataBlock = asset.objectDataBlock();
                     Path objectDataFile = outputDir.resolve("object_data.block");
                     copyBlock(objectDataBlock, objectDataFile, fc);
                 }
             }
-            
+
             if (level > 1) {
                 Path objectDataDir = outputDir.resolve("object_data");
-                
+
                 if (Files.notExists(objectDataDir)) {
                     Files.createDirectory(objectDataDir);
                 }
-                
+
                 for (SerializedObjectData od : asset.objectData()) {
                     String objectDataName = String.format("%010d", od.id());
                     Path objectDataFile = objectDataDir.resolve(objectDataName + ".block");
                     ByteBuffer objectDataBuffer = od.buffer();
                     objectDataBuffer.rewind();
-                    
+
                     ByteBufferUtils.save(objectDataFile, objectDataBuffer);
                 }
             }
@@ -112,7 +112,7 @@ public class AssetUnpack extends AssetCommand {
             L.log(Level.WARNING, "Can't unpack asset file " + file, ex);
         }
     }
-    
+
     private void copyBlock(DataBlock block, Path file, FileChannel fc) throws IOException {
         try (FileChannel fcOut = FileChannel.open(file, CREATE, WRITE)) {
             fc.transferTo(block.offset(), block.length(), fcOut);

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/command/bundle/BundleCommand.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/command/bundle/BundleCommand.java
@@ -24,9 +24,9 @@ import java.util.logging.Logger;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public abstract class BundleCommand extends RecursiveFileCommand {
-    
+
     private static final Logger L = LogUtils.getLogger();
-        
+
     @Override
     protected void runFileRecursive(Path file) {
         try (BundleReader reader = new BundleReader(file)) {
@@ -36,11 +36,11 @@ public abstract class BundleCommand extends RecursiveFileCommand {
             L.log(Level.WARNING, "Can't open asset bundle " + file, ex);
         }
     }
-    
+
     @Override
     protected boolean fileFilter(Path file) {
         return BundleUtils.isBundle(file);
     }
-    
+
     protected abstract void runBundle(Path file, Bundle bundle);
 }

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/command/bundle/BundleInfo.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/command/bundle/BundleInfo.java
@@ -32,7 +32,7 @@ import org.apache.commons.lang3.tuple.Pair;
     commandDescription = "Show bundle information."
 )
 public class BundleInfo extends BundleCommand {
-    
+
     @ParametersDelegate
     private final OutputFormatDelegate outputFormat = new OutputFormatDelegate();
 
@@ -41,19 +41,19 @@ public class BundleInfo extends BundleCommand {
         if (outputFormat.get() == OutputFormat.TEXT) {
             output().println(file);
         }
-        
+
         List<TableModel> tables = new ArrayList<>();
         tables.add(new TableModel("Header", buildHeaderTable(bundle.header())));
-        
+
         TablePrinter tablePrinter = TablePrinter.fromOutputFormat(outputFormat.get(), output());
         tablePrinter.file(file);
         tablePrinter.print(tables);
     }
-    
+
     private Table<Integer, Integer, Object> buildHeaderTable(BundleHeader header) {
         TableBuilder table = new TableBuilder();
         table.row("Field", "Value");
-        
+
         table.row("signature", header.signature());
         table.row("streamVersion", header.streamVersion());
         table.row("unityVersion", header.unityVersion());
@@ -62,23 +62,23 @@ public class BundleInfo extends BundleCommand {
         table.row("headerSize", header.headerSize());
         table.row("numberOfLevelsToDownload", header.numberOfLevelsToDownload());
         table.row("numberOfLevels", header.numberOfLevels());
-        
+
         List<Pair<Long, Long>> levelByteEnds = header.levelByteEnd();
         for (int i = 0; i < levelByteEnds.size(); i++) {
             Pair<Long, Long> levelByteEnd = levelByteEnds.get(i);
             table.row("levelByteEnd[" + i + "][0]", levelByteEnd.getLeft());
             table.row("levelByteEnd[" + i + "][1]", levelByteEnd.getRight());
         }
-        
+
         if (header.streamVersion() >= 2) {
             table.row("completeFileSize", header.completeFileSize());
         }
-        
+
         if (header.streamVersion() >= 3) {
             table.row("dataHeaderSize", header.dataHeaderSize());
         }
-        
+
         return table.get();
     }
-    
+
 }

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/command/bundle/BundleList.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/command/bundle/BundleList.java
@@ -32,20 +32,20 @@ import java.util.List;
     commandDescription = "List all files in bundles."
 )
 public class BundleList extends BundleCommand {
-    
+
     @ParametersDelegate
     private final OutputFormatDelegate outputFormat = new OutputFormatDelegate();
-    
+
     @Override
     protected void runBundle(Path file, Bundle bundle) {
         if (outputFormat.get() == OutputFormat.TEXT) {
             output().println(file);
         }
-        
+
         TableModel tableModel = new TableModel("Files", buildEntryTable(bundle));
         TextTableFormat format = tableModel.format();
         format.columnFormatter(2, Formatters::hex);
-        
+
         List<TableModel> tables = new ArrayList<>();
         tables.add(tableModel);
 
@@ -53,15 +53,15 @@ public class BundleList extends BundleCommand {
         tablePrinter.file(file);
         tablePrinter.print(tables);
     }
-    
+
     private Table<Integer, Integer, Object> buildEntryTable(Bundle bundle) {
         TableBuilder table = new TableBuilder();
         table.row("Name", "Size", "Offset");
-        
+
         bundle.entryInfos().forEach(entry -> {
             table.row(entry.name(), entry.size(), entry.offset());
         });
-        
+
         return table.get();
     }
 }

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/command/bundle/BundlePack.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/command/bundle/BundlePack.java
@@ -32,7 +32,7 @@ import java.util.logging.Logger;
 public class BundlePack extends FileCommand {
 
     private static final Logger L = LogUtils.getLogger();
-    
+
     @Parameter(
         names = {"-o", "--output"},
         description = "Asset bundle output file",
@@ -46,7 +46,7 @@ public class BundlePack extends FileCommand {
             String fileName = PathUtils.getBaseName(file);
             outFile = file.getParent().resolve(fileName + ".unity3d");
         }
-            
+
         Bundle bundle = new Bundle();
         try (BundleWriter bundleWriter = new BundleWriter(outFile)) {
             BundleProps.read(file, bundle);

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/command/bundle/BundleProps.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/command/bundle/BundleProps.java
@@ -1,11 +1,11 @@
 /*
-** 2015 December 06
-**
-** The author disclaims copyright to this source code. In place of
-** a legal notice, here is a blessing:
-**    May you do good and not evil.
-**    May you find forgiveness for yourself and forgive others.
-**    May you share freely, never taking more than you give.
+ ** 2015 December 06
+ **
+ ** The author disclaims copyright to this source code. In place of
+ ** a legal notice, here is a blessing:
+ **    May you do good and not evil.
+ **    May you find forgiveness for yourself and forgive others.
+ **    May you share freely, never taking more than you give.
  */
 package info.ata4.disunity.cli.command.bundle;
 
@@ -33,50 +33,50 @@ import java.util.stream.Collectors;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 class BundleProps {
-    
+
     private static final Charset CHARSET = Charset.forName("US-ASCII");
-    
+
     boolean compressed;
     int streamVersion;
     String unityVersion;
     String unityRevision;
     List<String> files;
 
-    static void write(Path propsFile, Bundle bundle) throws IOException {            
+    static void write(Path propsFile, Bundle bundle) throws IOException {
         BundleProps props = new BundleProps();
         BundleHeader header = bundle.header();
         props.compressed = header.compressed();
         props.streamVersion = header.streamVersion();
         props.unityVersion = header.unityVersion().toString();
         props.unityRevision = header.unityRevision().toString();
-        
+
         props.files = bundle.entryInfos().stream()
             .map(entry -> entry.name())
             .collect(Collectors.toList());
-        
+
         try (Writer writer = Files.newBufferedWriter(propsFile,
                 CHARSET, WRITE, CREATE, TRUNCATE_EXISTING)) {
             Gson gson = new GsonBuilder().setPrettyPrinting().create();
             gson.toJson(props, writer);
         }
     }
-    
+
     static void read(Path propsFile, Bundle bundle) throws IOException {
         BundleProps props;
-        
+
         try (Reader reader = Files.newBufferedReader(propsFile, CHARSET)) {
             props = new Gson().fromJson(reader, BundleProps.class);
         }
-        
+
         BundleHeader header = bundle.header();
         header.compressed(props.compressed);
         header.streamVersion(props.streamVersion);
         header.unityVersion(new UnityVersion(props.unityVersion));
         header.unityRevision(new UnityVersion(props.unityRevision));
-        
+
         String bundleName = PathUtils.getBaseName(propsFile);
         Path bundleDir = propsFile.resolveSibling(bundleName);
-        
+
         props.files.stream().map(bundleDir::resolve).forEach(file -> {
             bundle.entries().add(new BundleExternalEntry(file));
         });

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/command/bundle/BundleRoot.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/command/bundle/BundleRoot.java
@@ -20,11 +20,11 @@ import java.io.PrintWriter;
  */
 @Parameters
 public class BundleRoot extends Command {
-    
+
     @Override
     public void init(JCommander commander, PrintWriter out) {
         super.init(commander, out);
-        
+
         addSubCommand("list", new BundleList());
         addSubCommand("info", new BundleInfo());
         addSubCommand("pack", new BundlePack());

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/command/bundle/BundleUnpack.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/command/bundle/BundleUnpack.java
@@ -36,22 +36,22 @@ import java.util.logging.Logger;
     commandDescription = "Extract files from bundles."
 )
 public class BundleUnpack extends FileCommand {
-    
+
     private static final Logger L = LogUtils.getLogger();
-    
+
     @Parameter(
         names = {"-o", "--output"},
         description = "Output directory",
         converter = PathConverter.class
     )
     private Path outputDir;
-    
+
     @Parameter(
         names = {"-f", "--filename"},
         description = "Extract file with this name only."
     )
     private String filename;
-    
+
     @Parameter(
         names = {"-p", "--prop"},
         description = "Write bundle property file."
@@ -59,13 +59,13 @@ public class BundleUnpack extends FileCommand {
     private boolean writeProp;
 
     @Override
-    protected void runFile(Path file) {    
+    protected void runFile(Path file) {
         try (BundleReader bundleReader = new BundleReader(file)) {
             Bundle bundle = bundleReader.read();
-            
+
             AtomicInteger done = new AtomicInteger();
             long total = bundle.entryInfos().size();
-            
+
             // define output directory, if not yet defined
             if (outputDir == null) {
                 // if there's only one file inside the bundle, then don't bother
@@ -77,7 +77,7 @@ public class BundleUnpack extends FileCommand {
                     outputDir = file.resolveSibling(fileName);
                 }
             }
-            
+
             try {
                 bundle.entries()
                     .stream()
@@ -96,7 +96,7 @@ public class BundleUnpack extends FileCommand {
             } catch (UncheckedIOException ex) {
                 throw ex.getCause();
             }
-            
+
             if (writeProp && filename == null) {
                 String bundleName = outputDir.getFileName().toString();
                 Path propsFile = outputDir.getParent().resolve(bundleName + ".json");

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/converters/PathConverter.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/converters/PathConverter.java
@@ -23,5 +23,5 @@ public class PathConverter implements IStringConverter<Path> {
     public Path convert(String value) {
         return Paths.get(value);
     }
-    
+
 }

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/util/Formatters.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/util/Formatters.java
@@ -14,30 +14,30 @@ package info.ata4.disunity.cli.util;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class Formatters {
-    
+
     private Formatters() {
     }
 
-    public static String hex(Object v) {        
+    public static String hex(Object v) {
         if (!(v instanceof Number)) {
             return String.valueOf(v);
         }
         Number n = (Number) v;
         return String.format("%08x", n.intValue());
     }
-    
+
     public static String byteCount(Object v) {
         if (!(v instanceof Number)) {
             return String.valueOf(v);
         }
-        
+
         long bytes = ((Number) v).longValue();
-        
+
         int unit = 1024;
         if (bytes < unit) {
             return bytes + " B";
         }
-        
+
         int exp = (int) (Math.log(bytes) / Math.log(unit));
         String pre = "KMGTPE".charAt(exp - 1) + "i";
         return String.format("%.2f %sB", bytes / Math.pow(unit, exp), pre);

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/util/JsonTablePrinter.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/util/JsonTablePrinter.java
@@ -25,37 +25,37 @@ import java.util.Collection;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class JsonTablePrinter extends TablePrinter {
-    
+
     public JsonTablePrinter(PrintWriter out) {
         super(out);
     }
-    
+
     public JsonTablePrinter withFile(Path file) {
         this.file = file;
         return this;
     }
-    
+
     @Override
-    public void print(TableModel model) {        
+    public void print(TableModel model) {
         print(Arrays.asList(model));
     }
-    
+
     @Override
     public void print(Collection<TableModel> models) {
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         JsonObject jsonRoot = new JsonObject();
-        
+
         if (file != null) {
             jsonRoot.add("file", new JsonPrimitive(file.toString()));
         }
-        
+
         models.forEach(model -> {
             jsonRoot.add(model.name().toLowerCase(), tableToJson(model.table(), gson));
         });
-        
+
         gson.toJson(jsonRoot, out);
     }
-    
+
     private JsonArray tableToJson(Table<Integer, Integer, Object> table, Gson gson) {
         JsonArray jsonTable = new JsonArray();
 
@@ -76,11 +76,11 @@ public class JsonTablePrinter extends TablePrinter {
         });
 
         JsonObject jsonRoot = new JsonObject();
-        
+
         if (file != null) {
             jsonRoot.add("file", new JsonPrimitive(file.toString()));
         }
-        
+
         return jsonTable;
     }
 }

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/util/TableBuilder.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/util/TableBuilder.java
@@ -19,9 +19,9 @@ import java.util.OptionalInt;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class TableBuilder<T> {
-    
+
     private final Table<Integer, Integer, T> table = TreeBasedTable.create();
-    
+
     public TableBuilder row(T... value) {
         int row = table.rowKeySet().size();
         for (int col = 0; col < value.length; col++) {
@@ -29,10 +29,10 @@ public class TableBuilder<T> {
         }
         return this;
     }
-    
+
     public TableBuilder append(T... value) {
         int row = table.rowKeySet().size() - 1;
-        
+
         // check for empty table
         if (row < 0) {
             return this;
@@ -41,11 +41,11 @@ public class TableBuilder<T> {
         Map<Integer, T> rowMap = table.row(row);
         OptionalInt colMax = rowMap.keySet().stream().mapToInt(Integer::valueOf).max();
         int colOffset = colMax.isPresent() ? colMax.getAsInt() + 1 : 0;
-        
+
         for (int col = 0; col < value.length; col++) {
             table.put(row, colOffset + col, value[col]);
         }
-        
+
         return this;
     }
 

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/util/TableModel.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/util/TableModel.java
@@ -16,7 +16,7 @@ import com.google.common.collect.Table;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class TableModel {
-    
+
     private final Table<Integer, Integer, Object> table;
     private final String name;
     private boolean columnHeader = true;
@@ -26,15 +26,15 @@ public class TableModel {
         this.name = name;
         this.table = table;
     }
-    
+
     public Table<Integer, Integer, Object> table() {
         return table;
     }
-    
+
     public TextTableFormat format() {
         return format;
     }
-    
+
     public void format(TextTableFormat format) {
         this.format = format;
     }

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/util/TablePrinter.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/util/TablePrinter.java
@@ -19,30 +19,30 @@ import java.util.Collection;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public abstract class TablePrinter {
-    
+
     public static TablePrinter fromOutputFormat(OutputFormat format, PrintWriter out) {
         switch (format) {
             case JSON:
                 return new JsonTablePrinter(out);
-                
+
             default:
                 return new TextTablePrinter(out);
         }
     }
-    
+
     protected final PrintWriter out;
     protected Path file;
 
     public TablePrinter(PrintWriter out) {
         this.out = out;
     }
-    
+
     public void file(Path file) {
         this.file = file;
     }
-    
+
     public abstract void print(TableModel model);
-    
+
     public void print(Collection<TableModel> models) {
         models.forEach(this::print);
     }

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/util/TextTableFormat.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/util/TextTableFormat.java
@@ -21,44 +21,44 @@ import org.apache.commons.lang3.StringUtils;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class TextTableFormat {
-    
+
     private final Map<Integer, Integer> columnWidths = new HashMap<>();
     private final Map<Integer, TextTableAlignment> columnAlignments = new HashMap<>();
     private final Map<Integer, Function<Object, String>> columnFormatters = new HashMap<>();
     private int numColumns;
-    
+
     public void columnWidth(int column, int width) {
         columnWidths.put(column, width);
     }
-    
+
     public int columnWidth(int column) {
         return columnWidths.get(column);
     }
-    
+
     public void columnAlignment(int column, TextTableAlignment align) {
         columnAlignments.put(column, align);
     }
-    
+
     public TextTableAlignment columnAlignment(int column) {
         return columnAlignments.get(column);
     }
-    
+
     public void columnFormatter(int column, Function<Object, String> formatter) {
         columnFormatters.put(column, formatter);
     }
-    
+
     public Function<Object, String> columnFormatter(int column) {
         return columnFormatters.get(column);
     }
-    
+
     void configure(TableModel model) {
         numColumns = 0;
-        
+
         model.table().columnKeySet().stream().forEach(columnKey -> {
             if (!columnFormatters.containsKey(columnKey)) {
                 columnFormatters.put(columnKey, String::valueOf);
             }
-            
+
             // set minimum column width if not already defined
             if (!columnWidths.containsKey(columnKey)) {
                 columnWidths.put(columnKey, model.table()
@@ -71,7 +71,7 @@ public class TextTableFormat {
                     .getAsInt()
                 );
             }
-            
+
             if (!columnAlignments.containsKey(columnKey)
                     || columnAlignments.get(columnKey) == TextTableAlignment.AUTO) {
                 // count class types
@@ -90,40 +90,40 @@ public class TextTableFormat {
                     .max((v1, v2) -> Long.compare(v1.getValue(), v2.getValue()));
 
                 Class columnType = Object.class;
-                
+
                 if (topClassEntry.isPresent()) {
                     columnType = topClassEntry.get().getKey();
                 }
-                
+
                 // align number columns to the right for better readability
                 boolean isNumber = Number.class.isAssignableFrom(columnType);
                 TextTableAlignment align;
-                
+
                 if (isNumber) {
                     align = TextTableAlignment.RIGHT;
                 } else {
                     align = TextTableAlignment.LEFT;
                 }
-                
+
                 columnAlignments.put(columnKey, align);
             }
-            
+
             numColumns++;
         });
     }
-    
+
     int tableWidth(String cellSeparator) {
         return columnWidths.values().stream()
                 .reduce(0, (a, b) -> a + b)
                 + cellSeparator.length() * (columnWidths.size() - 1);
     }
-    
+
     String formatCell(Object value, int column) {
         int width = columnWidths.get(column);
         TextTableAlignment align = columnAlignments.get(column);
         Function<Object, String> formatter = columnFormatters.get(column);
         String content = formatter.apply(value);
-        
+
         if (content.length() > width) {
             // truncate
             content = StringUtils.abbreviate(content, width);
@@ -141,12 +141,12 @@ public class TextTableFormat {
                     break;
             }
         }
-        
+
         return content;
     }
-    
+
     int numColumns() {
         return numColumns;
     }
-    
+
 }

--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/util/TextTablePrinter.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/util/TextTablePrinter.java
@@ -18,7 +18,7 @@ import org.apache.commons.lang3.StringUtils;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class TextTablePrinter extends TablePrinter {
-    
+
     private final char rowSeparator = '-';
     private final char nameSeparator = '=';
     private final String cellSeparator = "  ";
@@ -31,27 +31,27 @@ public class TextTablePrinter extends TablePrinter {
     public void print(TableModel model) {
         TextTableFormat format = model.format();
         format.configure(model);
-        
+
         out.println(file);
-        
+
         // print table name
         String name = model.name();
         name = " " + name + " ";
         int size = Math.max(name.length() + 2, format.tableWidth(cellSeparator));
         name = StringUtils.center(name, size, nameSeparator);
         out.println(name);
-        
+
         // print cells
         model.table().cellSet().forEach(cell -> printCell(model, format, cell));
         out.println();
         out.println();
     }
-    
+
     private void printCell(TableModel model, TextTableFormat format, Table.Cell<Integer, Integer, Object> cell) {
         int numColumns = format.numColumns();
         int colKey = cell.getColumnKey();
         int rowKey = cell.getRowKey();
-        
+
         // print new line after the last cell of a row
         if (colKey == 0) {
             if (rowKey != 0) {
@@ -69,7 +69,7 @@ public class TextTablePrinter extends TablePrinter {
                 out.println();
             }
         }
-        
+
         out.print(format.formatCell(cell.getValue(), colKey));
 
         // print cell separator unless it's the last cell

--- a/disunity-core/src/main/java/info/ata4/disunity/DisUnity.java
+++ b/disunity-core/src/main/java/info/ata4/disunity/DisUnity.java
@@ -11,7 +11,7 @@ package info.ata4.disunity;
 
 /**
  * DisUnity program metadata.
- * 
+ *
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class DisUnity {
@@ -19,15 +19,15 @@ public class DisUnity {
     public static String getName() {
         return "DisUnity";
     }
-    
+
     public static String getProgramName() {
         return "disunity";
     }
-    
+
     public static String getVersion() {
         return "0.5.0";
     }
-    
+
     public static String getSignature() {
         return getName() + " v" + getVersion();
     }

--- a/disunity-core/src/main/java/info/ata4/junity/UnityGUID.java
+++ b/disunity-core/src/main/java/info/ata4/junity/UnityGUID.java
@@ -22,13 +22,13 @@ import java.util.UUID;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class UnityGUID implements Struct {
-    
+
     private UUID uuid;
-    
+
     public UUID uuid() {
         return uuid;
     }
-    
+
     public void uuid(UUID uuid) {
         this.uuid = Objects.requireNonNull(uuid);
     }

--- a/disunity-core/src/main/java/info/ata4/junity/UnityHash128.java
+++ b/disunity-core/src/main/java/info/ata4/junity/UnityHash128.java
@@ -20,9 +20,9 @@ import javax.xml.bind.DatatypeConverter;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class UnityHash128 implements Struct {
-    
+
     private final byte[] hash = new byte[16];
-    
+
     public byte[] hash() {
         return hash;
     }

--- a/disunity-core/src/main/java/info/ata4/junity/UnityStruct.java
+++ b/disunity-core/src/main/java/info/ata4/junity/UnityStruct.java
@@ -18,15 +18,15 @@ import info.ata4.io.Struct;
 public abstract class UnityStruct<T extends Struct> implements Struct {
 
     protected final Class<T> elementFactory;
-    
+
     public UnityStruct(Class<T> elementFactory) {
         this.elementFactory = elementFactory;
     }
-    
+
     public Class<T> elementFactory() {
         return elementFactory;
     }
-    
+
     protected T createElement() {
         try {
             return elementFactory.newInstance();
@@ -34,5 +34,5 @@ public abstract class UnityStruct<T extends Struct> implements Struct {
             throw new RuntimeException(ex);
         }
     }
-    
+
 }

--- a/disunity-core/src/main/java/info/ata4/junity/UnityTableStruct.java
+++ b/disunity-core/src/main/java/info/ata4/junity/UnityTableStruct.java
@@ -21,13 +21,13 @@ import java.util.List;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class UnityTableStruct<T extends Struct> extends UnityStruct<T> {
-    
+
     private final List<T> elements = new ArrayList<>();
 
     public UnityTableStruct(Class<T> elementFactory) {
         super(elementFactory);
     }
-    
+
     public List<T> elements() {
         return elements;
     }
@@ -40,7 +40,7 @@ public class UnityTableStruct<T extends Struct> extends UnityStruct<T> {
             elements.add(readEntry(in));
         }
     }
-    
+
     protected T readEntry(DataReader in) throws IOException {
         T element = createElement();
         in.readStruct(element);
@@ -55,7 +55,7 @@ public class UnityTableStruct<T extends Struct> extends UnityStruct<T> {
             writeEntry(out, element);
         }
     }
-    
+
     protected void writeEntry(DataWriter out, T element) throws IOException {
         out.writeStruct(element);
     }

--- a/disunity-core/src/main/java/info/ata4/junity/UnityVersion.java
+++ b/disunity-core/src/main/java/info/ata4/junity/UnityVersion.java
@@ -13,17 +13,17 @@ import java.util.Objects;
 
 /**
  * Unity engine version string container.
- * 
+ *
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class UnityVersion implements Comparable<UnityVersion> {
-    
+
     private byte major;
     private byte minor;
     private byte patch;
     private String build;
     private String raw;
-    
+
     public UnityVersion(String version) {
         try {
             major = partFromString(version.substring(0, 1));
@@ -35,11 +35,11 @@ public class UnityVersion implements Comparable<UnityVersion> {
             raw = version;
         }
     }
-    
+
     public UnityVersion() {
         this("1.0.0f1");
     }
-    
+
     private byte partFromString(String part) {
         if (part.equals("x")) {
             return -1;
@@ -47,7 +47,7 @@ public class UnityVersion implements Comparable<UnityVersion> {
             return Byte.valueOf(part);
         }
     }
-    
+
     private String partToString(byte part) {
         if (part == -1) {
             return "x";
@@ -55,7 +55,7 @@ public class UnityVersion implements Comparable<UnityVersion> {
             return String.valueOf(part);
         }
     }
-    
+
     public boolean isValid() {
         return raw == null;
     }
@@ -91,7 +91,7 @@ public class UnityVersion implements Comparable<UnityVersion> {
     public void build(String build) {
         this.build = build;
     }
-    
+
     @Override
     public String toString() {
         if (raw != null) {
@@ -101,7 +101,7 @@ public class UnityVersion implements Comparable<UnityVersion> {
                     partToString(minor), partToString(patch), build);
         }
     }
-    
+
     @Override
     public int hashCode() {
         if (raw != null) {
@@ -179,7 +179,7 @@ public class UnityVersion implements Comparable<UnityVersion> {
     public boolean lesserThan(UnityVersion that) {
         return this.compareTo(that) == 1;
     }
-    
+
     public boolean greaterThan(UnityVersion that) {
         return this.compareTo(that) == -1;
     }

--- a/disunity-core/src/main/java/info/ata4/junity/bundle/Bundle.java
+++ b/disunity-core/src/main/java/info/ata4/junity/bundle/Bundle.java
@@ -17,7 +17,7 @@ import java.util.List;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class Bundle {
-    
+
     private final BundleHeader header = new BundleHeader();
     private final List<BundleEntry> entries = new ArrayList<>();
     private final List<BundleEntryInfo> entryInfos = new ArrayList<>();

--- a/disunity-core/src/main/java/info/ata4/junity/bundle/BundleEntry.java
+++ b/disunity-core/src/main/java/info/ata4/junity/bundle/BundleEntry.java
@@ -18,19 +18,19 @@ import org.apache.commons.io.FilenameUtils;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public abstract class BundleEntry {
-    
+
     public static boolean isLibrary(BundleEntry entry) {
         String ext = FilenameUtils.getExtension(entry.name());
         return ext.equals("dll") || ext.equals("mdb");
     }
-    
+
     public static boolean isResource(BundleEntry entry) {
         String ext = FilenameUtils.getExtension(entry.name());
         return ext.equals("resource");
     }
-    
+
     public abstract String name();
-    
+
     public abstract long size();
 
     public abstract InputStream inputStream() throws IOException;

--- a/disunity-core/src/main/java/info/ata4/junity/bundle/BundleEntryInfo.java
+++ b/disunity-core/src/main/java/info/ata4/junity/bundle/BundleEntryInfo.java
@@ -20,7 +20,7 @@ import java.io.IOException;
  * @unity StreamingInfo
  */
 public class BundleEntryInfo implements Struct {
-    
+
     private String name;
     private long offset;
     private long size;
@@ -48,7 +48,7 @@ public class BundleEntryInfo implements Struct {
     public void size(long size) {
         this.size = size;
     }
-    
+
     @Override
     public void read(DataReader in) throws IOException {
         name = in.readStringNull();

--- a/disunity-core/src/main/java/info/ata4/junity/bundle/BundleException.java
+++ b/disunity-core/src/main/java/info/ata4/junity/bundle/BundleException.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 
 /**
  * IOException used for asset bundle errors.
- * 
+ *
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class BundleException extends IOException {

--- a/disunity-core/src/main/java/info/ata4/junity/bundle/BundleExternalEntry.java
+++ b/disunity-core/src/main/java/info/ata4/junity/bundle/BundleExternalEntry.java
@@ -19,7 +19,7 @@ import java.nio.file.Path;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class BundleExternalEntry extends BundleEntry {
-    
+
     private final Path file;
 
     public BundleExternalEntry(Path file) {
@@ -44,5 +44,5 @@ public class BundleExternalEntry extends BundleEntry {
     public InputStream inputStream() throws IOException {
         return Files.newInputStream(file);
     }
-    
+
 }

--- a/disunity-core/src/main/java/info/ata4/junity/bundle/BundleInternalEntry.java
+++ b/disunity-core/src/main/java/info/ata4/junity/bundle/BundleInternalEntry.java
@@ -18,7 +18,7 @@ import java.io.InputStream;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class BundleInternalEntry extends BundleEntry {
-    
+
     private final BundleEntryInfo info;
     private final IOFunction<BundleEntryInfo, InputStream> inputStreamFactory;
 
@@ -27,12 +27,12 @@ public class BundleInternalEntry extends BundleEntry {
         this.info = info;
         this.inputStreamFactory = isFactory;
     }
-    
+
     @Override
     public String name() {
         return info.name();
     }
-    
+
     @Override
     public long size() {
         return info.size();

--- a/disunity-core/src/main/java/info/ata4/junity/bundle/BundleUtils.java
+++ b/disunity-core/src/main/java/info/ata4/junity/bundle/BundleUtils.java
@@ -26,21 +26,21 @@ import org.apache.commons.io.IOUtils;
 
 /**
  * Asset bundle file utility class.
- * 
+ *
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class BundleUtils {
-    
+
     private static final Charset PROP_CHARSET = Charset.forName("US-ASCII");
-    
+
     private BundleUtils() {
     }
-    
+
     public static boolean isBundle(Path file) {
         if (!Files.isRegularFile(file)) {
             return false;
         }
-        
+
         try (InputStream is = Files.newInputStream(file)) {
             byte[] header = new byte[8];
             is.read(header);
@@ -51,10 +51,10 @@ public class BundleUtils {
             return false;
         }
     }
-        
+
     public static SeekableByteChannel byteChannelForEntry(BundleEntry entry) throws IOException {
         SeekableByteChannel chan;
-        
+
         // check if the entry is larger than 128 MiB
         long size = entry.size();
         if (size > 1 << 27) {
@@ -69,10 +69,10 @@ public class BundleUtils {
             bb.flip();
             chan = new ByteBufferChannel(bb);
         }
-        
+
         return chan;
     }
-    
+
     public static DataReader dataReaderForEntry(BundleEntry entry) throws IOException {
         return DataReaders.forSeekableByteChannel(BundleUtils.byteChannelForEntry(entry));
     }

--- a/disunity-core/src/main/java/info/ata4/junity/progress/Progress.java
+++ b/disunity-core/src/main/java/info/ata4/junity/progress/Progress.java
@@ -16,6 +16,6 @@ import java.util.Optional;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public interface Progress {
-    
+
     void update(Optional<String> stage, double complete);
 }

--- a/disunity-core/src/main/java/info/ata4/junity/serialize/SerializedFile.java
+++ b/disunity-core/src/main/java/info/ata4/junity/serialize/SerializedFile.java
@@ -20,44 +20,44 @@ import java.util.List;
  * @unity SerializedFile
  */
 public class SerializedFile {
-    
+
     // struct fields
     private final SerializedFileHeader header = new SerializedFileHeader();
     private final SerializedFileMetadata metadata = new SerializedFileMetadata();
-    
+
     // data block fields
     private final DataBlock headerBlock = new DataBlock();
     private final DataBlock metadataBlock = new DataBlock();
     private final DataBlock objectDataBlock = new DataBlock();
-    
+
     // misc fields
     private final List<SerializedObjectData> objectData = new ArrayList<>();
     private ByteBuffer audioBuffer;
-    
+
     public SerializedFileHeader header() {
         return header;
     }
-    
+
     public SerializedFileMetadata metadata() {
         return metadata;
     }
-    
+
     public List<SerializedObjectData> objectData() {
         return objectData;
     }
-    
+
     public DataBlock headerBlock() {
         return headerBlock;
     }
-    
+
     public DataBlock metadataBlock() {
         return metadataBlock;
     }
-    
+
     public DataBlock objectDataBlock() {
         return objectDataBlock;
     }
-    
+
     public List<DataBlock> dataBlocks() {
         List<DataBlock> blocks = new ArrayList<>();
         blocks.add(headerBlock);

--- a/disunity-core/src/main/java/info/ata4/junity/serialize/SerializedFileHeader.java
+++ b/disunity-core/src/main/java/info/ata4/junity/serialize/SerializedFileHeader.java
@@ -20,13 +20,13 @@ import java.io.IOException;
  * @unity SerializedFileHeader
  */
 public class SerializedFileHeader implements Struct {
-    
+
     // size of the structure data
     private long metadataSize;
-    
+
     // size of the whole asset file
     private long fileSize;
-    
+
     // 5 = 1.2 - 2.0
     // 6 = 2.1 - 2.6
     // 7 = 3.0 (?)
@@ -38,13 +38,13 @@ public class SerializedFileHeader implements Struct {
     // 14 = 5.0
     // 15 = 5.0 (p3 and newer)
     private int version;
-    
+
     // offset to the serialized data
     private long dataOffset;
-    
+
     // byte order of the serialized data?
     private byte endianness;
-    
+
     // unused
     private final byte[] reserved = new byte[3];
 
@@ -87,7 +87,7 @@ public class SerializedFileHeader implements Struct {
     public void endianness(byte endianness) {
         this.endianness = endianness;
     }
-    
+
     @Override
     public void read(DataReader in) throws IOException {
         metadataSize = in.readInt();

--- a/disunity-core/src/main/java/info/ata4/junity/serialize/SerializedFileMetadata.java
+++ b/disunity-core/src/main/java/info/ata4/junity/serialize/SerializedFileMetadata.java
@@ -45,37 +45,37 @@ import java.util.logging.Logger;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class SerializedFileMetadata implements Struct {
-    
+
     private static final Logger L = LogUtils.getLogger();
-    
+
     private final DataBlock typeTreeBlock = new DataBlock();
     private final DataBlock objectInfoBlock = new DataBlock();
     private final DataBlock objectIDBlock = new DataBlock();
     private final DataBlock externalsBlock = new DataBlock();
-    
+
     private TypeTree typeTree;
     private ObjectInfoTable objectInfoTable;
     private ObjectIdentifierTable objectIDTable;
     private FileIdentifierTable externals;
-    
+
     private int version;
-    
+
     public DataBlock typeTreeBlock() {
         return typeTreeBlock;
     }
-    
+
     public DataBlock objectInfoBlock() {
         return objectInfoBlock;
     }
-    
+
     public DataBlock objectIDBlock() {
         return objectIDBlock;
     }
-    
+
     public DataBlock externalsBlock() {
         return externalsBlock;
     }
-    
+
     public List<DataBlock> dataBlocks() {
         List<DataBlock> blocks = new ArrayList<>();
         blocks.add(typeTreeBlock());
@@ -84,43 +84,43 @@ public class SerializedFileMetadata implements Struct {
         blocks.add(externalsBlock());
         return blocks;
     }
-    
+
     public int version() {
         return version;
     }
-    
+
     public void version(int version) {
         this.version = version;
     }
-    
+
     public <T extends Type> TypeTree<T> typeTree() {
         return typeTree;
     }
-    
+
     public <T extends Type> void typeTree(TypeTree<T> typeTree) {
         this.typeTree = Objects.requireNonNull(typeTree);
     }
-    
+
     public <T extends ObjectInfo> ObjectInfoTable<T> objectInfoTable() {
         return objectInfoTable;
     }
-    
+
     public <T extends ObjectInfo> void objectInfoTable(ObjectInfoTable<T> objInfoTable) {
         this.objectInfoTable = Objects.requireNonNull(objInfoTable);
     }
-    
+
     public ObjectIdentifierTable objectIDTable() {
         return objectIDTable;
     }
-    
+
     public void objectIDTable(ObjectIdentifierTable objectIDTable) {
         this.objectIDTable = Objects.requireNonNull(objectIDTable);
     }
-    
+
     public <T extends FileIdentifier> FileIdentifierTable<T> externals() {
         return externals;
     }
-    
+
     public <T extends FileIdentifier> void externals(FileIdentifierTable<T> externals) {
         this.externals = Objects.requireNonNull(externals);
     }
@@ -135,12 +135,12 @@ public class SerializedFileMetadata implements Struct {
         } else {
             typeTree = new TypeTreeV1(TypeV1.class);
         }
-        
+
         typeTreeBlock.markBegin(in);
         in.readStruct(typeTree);
         typeTreeBlock.markEnd(in);
         L.log(Level.FINER, "typeTreeBlock: {0}", typeTreeBlock);
-        
+
         // load object info table
         if (version > 14) {
             objectInfoTable = new ObjectInfoTableV2(ObjectInfoV3.class);
@@ -149,12 +149,12 @@ public class SerializedFileMetadata implements Struct {
         } else {
             objectInfoTable = new ObjectInfoTableV1(ObjectInfoV1.class);
         }
-        
+
         objectInfoBlock.markBegin(in);
         in.readStruct(objectInfoTable);
         objectInfoBlock.markEnd(in);
         L.log(Level.FINER, "objectInfoBlock: {0}", objectInfoBlock);
-        
+
         // load object identifiers (Unity 5+ only)
         objectIDTable = new ObjectIdentifierTable();
         if (version > 10) {
@@ -163,14 +163,14 @@ public class SerializedFileMetadata implements Struct {
             objectIDBlock.markEnd(in);
             L.log(Level.FINER, "objectIDBlock: {0}", objectIDBlock);
         }
-        
+
         // load external references
         if (version > 5) {
             externals = new FileIdentifierTable(FileIdentifierV2.class);
         } else {
             externals = new FileIdentifierTable(FileIdentifierV1.class);
         }
-        
+
         externalsBlock.markBegin(in);
         in.readStruct(externals);
         externalsBlock.markEnd(in);
@@ -183,19 +183,19 @@ public class SerializedFileMetadata implements Struct {
         out.writeStruct(typeTree);
         typeTreeBlock.markEnd(out);
         L.log(Level.FINER, "typeTreeBlock: {0}", typeTreeBlock);
-        
+
         objectInfoBlock.markBegin(out);
         out.writeStruct(objectInfoTable);
         objectInfoBlock.markEnd(out);
         L.log(Level.FINER, "objectInfoBlock: {0}", objectInfoBlock);
-        
+
         if (version > 10) {
             objectIDBlock.markBegin(out);
             out.writeStruct(objectIDTable);
             objectIDBlock.markEnd(out);
             L.log(Level.FINER, "objectIDBlock: {0}", objectIDBlock);
         }
-        
+
         externalsBlock.markBegin(out);
         out.writeStruct(externals);
         externalsBlock.markEnd(out);

--- a/disunity-core/src/main/java/info/ata4/junity/serialize/SerializedFileReader.java
+++ b/disunity-core/src/main/java/info/ata4/junity/serialize/SerializedFileReader.java
@@ -36,25 +36,25 @@ import org.apache.commons.io.FilenameUtils;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class SerializedFileReader implements Closeable {
-    
+
     private static final Logger L = LogUtils.getLogger();
-    
+
     private final DataReader in;
     private SerializedFile serialized;
     private ByteBuffer resourceBuffer;
-    
+
     public SerializedFileReader(Path file) throws IOException {
         String fileName = file.getFileName().toString();
         String fileExt = FilenameUtils.getExtension(fileName);
-        
-        // load audio buffer if existing        
+
+        // load audio buffer if existing
         readResourceStream(file.resolveSibling(fileName + ".streamingResourceImage"));
         readResourceStream(file.resolveSibling(fileName + ".resS"));
-        
+
         // join split serialized files before loading
         if (fileExt.startsWith("split")) {
             L.fine("Found split serialized file");
-            
+
             fileName = FilenameUtils.removeExtension(fileName);
             List<Path> parts = new ArrayList<>();
             int splitIndex = 0;
@@ -66,52 +66,52 @@ public class SerializedFileReader implements Closeable {
                 if (Files.notExists(part)) {
                     break;
                 }
-                
+
                 L.log(Level.FINE, "Adding splinter {0}", part.getFileName());
-                
+
                 splitIndex++;
                 parts.add(part);
             }
-            
+
             // load all parts to one byte buffer
             in = DataReaders.forByteBuffer(ByteBufferUtils.load(parts));
         } else {
             in = DataReaders.forFile(file, READ);
         }
     }
-    
+
     public SerializedFileReader(DataReader in) {
         this.in = in;
     }
-    
+
     public SerializedFile read() throws IOException {
         this.serialized = new SerializedFile();
-        
+
         // header is always big endian
         in.order(ByteOrder.BIG_ENDIAN);
-        
+
         readHeader(in);
-        
+
         SerializedFileHeader header = serialized.header();
-        
+
         // older formats store the object data before the structure data
         if (header.version() < 9) {
             in.position(header.fileSize() - header.metadataSize() + 1);
         }
-        
+
         // newer formats use little endian for the rest of the file
         if (header.version() > 5) {
             in.order(ByteOrder.LITTLE_ENDIAN);
         }
-        
+
         readMetadata(in);
         readObjects(in);
-        
+
         serialized.audioBuffer(resourceBuffer);
-        
+
         return serialized;
     }
-    
+
     private void readHeader(DataReader in) throws IOException {
         DataBlock headerBlock = serialized.headerBlock();
         headerBlock.markBegin(in);
@@ -119,11 +119,11 @@ public class SerializedFileReader implements Closeable {
         headerBlock.markEnd(in);
         L.log(Level.FINER, "headerBlock: {0}", headerBlock);
     }
-    
+
     private void readMetadata(DataReader in) throws IOException {
         SerializedFileMetadata metadata = serialized.metadata();
         SerializedFileHeader header = serialized.header();
-        
+
         DataBlock metadataBlock = serialized.metadataBlock();
         metadataBlock.markBegin(in);
         metadata.version(header.version());
@@ -131,52 +131,52 @@ public class SerializedFileReader implements Closeable {
         metadataBlock.markEnd(in);
         L.log(Level.FINER, "metadataBlock: {0}", metadataBlock);
     }
-    
+
     private void readObjects(DataReader in) throws IOException {
         long ofsMin = Long.MAX_VALUE;
         long ofsMax = Long.MIN_VALUE;
-        
+
         SerializedFileHeader header = serialized.header();
         SerializedFileMetadata metadata = serialized.metadata();
-        
+
         Map<Long, ObjectInfo> objectInfoMap = metadata.objectInfoTable().infoMap();
         Map<Integer, TypeRoot<Type>> typeTreeMap = metadata.typeTree().typeMap();
         List<SerializedObjectData> objectData = serialized.objectData();
-        
+
         for (Map.Entry<Long, ObjectInfo> infoEntry : objectInfoMap.entrySet()) {
             ObjectInfo info = infoEntry.getValue();
             long id = infoEntry.getKey();
             long ofs = header.dataOffset() + info.offset();
-            
+
             ofsMin = Math.min(ofsMin, ofs);
             ofsMax = Math.max(ofsMax, ofs + info.length());
-            
+
             SerializedObjectData object = new SerializedObjectData(id);
             object.info(info);
-            
+
             // create and read object data buffer
             ByteBuffer buf = ByteBufferUtils.allocate((int) info.length());
-            
+
             in.position(ofs);
-            in.readBuffer(buf);            
-            
+            in.readBuffer(buf);
+
             object.buffer(buf);
-            
+
             // get type tree if possible
             TypeRoot typeRoot = typeTreeMap.get(info.typeID());
             if (typeRoot != null) {
                 object.typeTree(typeRoot.nodes());
             }
-            
+
             objectData.add(object);
         }
-        
+
         DataBlock objectDataBlock = serialized.objectDataBlock();
         objectDataBlock.offset(ofsMin);
         objectDataBlock.endOffset(ofsMax);
         L.log(Level.FINER, "objectDataBlock: {0}", objectDataBlock);
     }
-    
+
     private void readResourceStream(Path streamFile) throws IOException {
         if (Files.exists(streamFile)) {
             L.log(Level.FINE, "Found resource stream file {0}", streamFile.getFileName());

--- a/disunity-core/src/main/java/info/ata4/junity/serialize/SerializedFileWriter.java
+++ b/disunity-core/src/main/java/info/ata4/junity/serialize/SerializedFileWriter.java
@@ -1,11 +1,11 @@
 /*
-** 2015 December 03
-**
-** The author disclaims copyright to this source code. In place of
-** a legal notice, here is a blessing:
-**    May you do good and not evil.
-**    May you find forgiveness for yourself and forgive others.
-**    May you share freely, never taking more than you give.
+ ** 2015 December 03
+ **
+ ** The author disclaims copyright to this source code. In place of
+ ** a legal notice, here is a blessing:
+ **    May you do good and not evil.
+ **    May you find forgiveness for yourself and forgive others.
+ **    May you share freely, never taking more than you give.
  */
 package info.ata4.junity.serialize;
 
@@ -25,46 +25,46 @@ import java.util.logging.Logger;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class SerializedFileWriter implements Closeable {
-    
+
     private static final Logger L = LogUtils.getLogger();
-    
+
     private static final int META_PADDING = 4096;
     private static final int META_ALIGN = 16;
-    
+
     private final DataWriter out;
     private SerializedFile serialized;
-    
+
     public SerializedFileWriter(DataWriter out) {
         this.out = out;
     }
 
     public void write(SerializedFile serialized) throws IOException {
         this.serialized = serialized;
-        
+
         // header is always big endian
         out.order(ByteOrder.BIG_ENDIAN);
-        
+
         writeHeader(out);
-        
+
         SerializedFileHeader header = serialized.header();
-        
+
         // newer formats use little endian for the rest of the file
         if (header.version() > 5) {
             out.order(ByteOrder.LITTLE_ENDIAN);
         }
-        
+
         // older formats store the object data before the structure data
         if (header.version() < 9) {
             header.dataOffset(0);
-            
+
             writeObjects(out);
             out.writeUnsignedByte(header.version() > 5 ? 0 : 1);
-            
+
             writeMetadata(out);
             out.writeUnsignedByte(0);
         } else {
             writeMetadata(out);
-            
+
             long dataOffset = out.position();
 
             // calculate padding
@@ -76,28 +76,28 @@ public class SerializedFileWriter implements Closeable {
 
             header.dataOffset(dataOffset);
 
-            out.position(dataOffset);            
+            out.position(dataOffset);
             writeObjects(out);
-            
+
             // write updated path table
             out.position(serialized.metadata().objectInfoBlock().offset());
             out.writeStruct(serialized.metadata().objectInfoTable());
         }
-        
+
         // update header
         header.fileSize(out.size());
-        
+
         // FIXME: the metadata size is slightly off in comparison to original files
         int metadataOffset = header.version() < 9 ? 2 : 1;
-        
+
         header.metadataSize(serialized.metadataBlock().length() + metadataOffset);
-        
+
         // write updated header
         out.order(ByteOrder.BIG_ENDIAN);
         out.position(serialized.headerBlock().offset());
         out.writeStruct(header);
     }
-    
+
     private void writeHeader(DataWriter out) throws IOException {
         DataBlock headerBlock = serialized.headerBlock();
         headerBlock.markBegin(out);
@@ -105,11 +105,11 @@ public class SerializedFileWriter implements Closeable {
         headerBlock.markEnd(out);
         L.log(Level.FINER, "headerBlock: {0}", headerBlock);
     }
-    
+
     private void writeMetadata(DataWriter out) throws IOException {
         SerializedFileMetadata metadata = serialized.metadata();
         SerializedFileHeader header = serialized.header();
-        
+
         DataBlock metadataBlock = serialized.metadataBlock();
         metadataBlock.markBegin(out);
         metadata.version(header.version());
@@ -117,27 +117,27 @@ public class SerializedFileWriter implements Closeable {
         metadataBlock.markEnd(out);
         L.log(Level.FINER, "metadataBlock: {0}", metadataBlock);
     }
-    
+
     private void writeObjects(DataWriter out) throws IOException {
         long ofsMin = Long.MAX_VALUE;
         long ofsMax = Long.MIN_VALUE;
-        
+
         for (SerializedObjectData data : serialized.objectData()) {
             ByteBuffer bb = data.buffer();
             bb.rewind();
-            
+
             out.align(8);
-            
+
             ofsMin = Math.min(ofsMin, out.position());
             ofsMax = Math.max(ofsMax, out.position() + bb.remaining());
-            
-            ObjectInfo info = data.info();            
+
+            ObjectInfo info = data.info();
             info.offset(out.position() - serialized.header().dataOffset());
             info.length(bb.remaining());
 
             out.writeBuffer(bb);
         }
-        
+
         DataBlock objectDataBlock = serialized.objectDataBlock();
         objectDataBlock.offset(ofsMin);
         objectDataBlock.endOffset(ofsMax);
@@ -148,5 +148,5 @@ public class SerializedFileWriter implements Closeable {
     public void close() throws IOException {
         out.close();
     }
-    
+
 }

--- a/disunity-core/src/main/java/info/ata4/junity/serialize/SerializedObjectData.java
+++ b/disunity-core/src/main/java/info/ata4/junity/serialize/SerializedObjectData.java
@@ -19,16 +19,16 @@ import java.nio.ByteBuffer;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class SerializedObjectData {
-    
+
     private final long id;
     private ObjectInfo info;
     private ByteBuffer buffer;
     private Node<Type> typeTree;
-    
+
     public SerializedObjectData(long id) {
         this.id = id;
     }
-    
+
     public long id() {
         return id;
     }
@@ -36,7 +36,7 @@ public class SerializedObjectData {
     public ObjectInfo info() {
         return info;
     }
-    
+
     public void info(ObjectInfo info) {
         this.info = info;
     }
@@ -44,11 +44,11 @@ public class SerializedObjectData {
     public ByteBuffer buffer() {
         return buffer;
     }
-    
+
     public void buffer(ByteBuffer buffer) {
         this.buffer = buffer;
     }
-    
+
     public Node<Type> typeTree() {
         return typeTree;
     }

--- a/disunity-core/src/main/java/info/ata4/junity/serialize/fileidentifier/FileIdentifier.java
+++ b/disunity-core/src/main/java/info/ata4/junity/serialize/fileidentifier/FileIdentifier.java
@@ -16,21 +16,21 @@ import java.util.UUID;
 /**
  *
  * @author Nico Bergemann <barracuda415 at yahoo.de>
-  * @unity FileIdentifier 
+  * @unity FileIdentifier
  */
 public abstract class FileIdentifier implements Struct {
-    
+
     // Globally unique identifier of the referred asset. Unity displays these
     // as simple 16 byte hex strings with each byte swapped, but they can also
     // be represented according to the UUID standard.
     protected final UnityGUID guid = new UnityGUID();
-    
+
     // Path to the asset file. Only used if "type" is 0.
     protected String filePath;
-    
+
     // Reference type. Possible values are probably 0 to 3.
     protected int type;
-    
+
     public UUID guid() {
         return guid.uuid();
     }

--- a/disunity-core/src/main/java/info/ata4/junity/serialize/fileidentifier/FileIdentifierV2.java
+++ b/disunity-core/src/main/java/info/ata4/junity/serialize/fileidentifier/FileIdentifierV2.java
@@ -18,10 +18,10 @@ import java.io.IOException;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class FileIdentifierV2 extends FileIdentifierV1 {
-    
+
     // Path to the asset file?
     private String assetPath;
-    
+
     @Override
     public void read(DataReader in) throws IOException {
         assetPath = in.readStringNull();
@@ -33,7 +33,7 @@ public class FileIdentifierV2 extends FileIdentifierV1 {
         out.writeStringNull(assetPath);
         super.write(out);
     }
-    
+
     public String assetPath() {
         return assetPath;
     }

--- a/disunity-core/src/main/java/info/ata4/junity/serialize/objectidentifier/ObjectIdentifierTable.java
+++ b/disunity-core/src/main/java/info/ata4/junity/serialize/objectidentifier/ObjectIdentifierTable.java
@@ -19,7 +19,7 @@ import java.io.IOException;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class ObjectIdentifierTable extends UnityTableStruct<ObjectIdentifier> {
-    
+
     public ObjectIdentifierTable() {
         super(ObjectIdentifier.class);
     }

--- a/disunity-core/src/main/java/info/ata4/junity/serialize/objectinfo/ObjectInfo.java
+++ b/disunity-core/src/main/java/info/ata4/junity/serialize/objectinfo/ObjectInfo.java
@@ -12,24 +12,24 @@ package info.ata4.junity.serialize.objectinfo;
 import info.ata4.io.Struct;
 
 /**
- * 
+ *
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  * @unity SerializedFile::ObjectInfo
  */
 public abstract class ObjectInfo implements Struct {
-    
+
     // Object data offset
     protected long byteStart;
-    
+
     // Object data size
     protected long byteSize;
-    
+
     // Type ID, equal to classID if it's not a MonoBehaviour
     protected int typeID;
-    
+
     // Class ID, probably something else in asset format <=5
     protected int classID;
-    
+
     public long offset() {
         return byteStart;
     }
@@ -45,7 +45,7 @@ public abstract class ObjectInfo implements Struct {
     public void length(long length) {
         this.byteSize = length;
     }
-    
+
     public boolean isScript() {
         return typeID < 0;
     }
@@ -57,7 +57,7 @@ public abstract class ObjectInfo implements Struct {
     public void typeID(int typeID) {
         this.typeID = typeID;
     }
-    
+
     public int classID() {
         return classID;
     }

--- a/disunity-core/src/main/java/info/ata4/junity/serialize/objectinfo/ObjectInfoTable.java
+++ b/disunity-core/src/main/java/info/ata4/junity/serialize/objectinfo/ObjectInfoTable.java
@@ -19,9 +19,9 @@ import java.util.Objects;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public abstract class ObjectInfoTable<T extends ObjectInfo> extends UnityStruct<T> {
-    
+
     protected Map<Long, T> infoMap = new LinkedHashMap<>();
-    
+
     public ObjectInfoTable(Class<T> elementFactory) {
         super(elementFactory);
     }

--- a/disunity-core/src/main/java/info/ata4/junity/serialize/objectinfo/ObjectInfoTableV1.java
+++ b/disunity-core/src/main/java/info/ata4/junity/serialize/objectinfo/ObjectInfoTableV1.java
@@ -19,11 +19,11 @@ import java.util.Map;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class ObjectInfoTableV1<T extends ObjectInfo> extends ObjectInfoTable<T> {
-    
+
     public ObjectInfoTableV1(Class<T> elementFactory) {
         super(elementFactory);
     }
-        
+
     @Override
     public void read(DataReader in) throws IOException {
         int entries = in.readInt();

--- a/disunity-core/src/main/java/info/ata4/junity/serialize/objectinfo/ObjectInfoTableV2.java
+++ b/disunity-core/src/main/java/info/ata4/junity/serialize/objectinfo/ObjectInfoTableV2.java
@@ -23,7 +23,7 @@ public class ObjectInfoTableV2<T extends ObjectInfoV2> extends ObjectInfoTableV1
     public ObjectInfoTableV2(Class<T> elementFactory) {
         super(elementFactory);
     }
-    
+
     @Override
     public void read(DataReader in) throws IOException {
         int entries = in.readInt();
@@ -35,7 +35,7 @@ public class ObjectInfoTableV2<T extends ObjectInfoV2> extends ObjectInfoTableV1
             infoMap.put(pathID, info);
         }
     }
-    
+
     @Override
     public void write(DataWriter out) throws IOException {
         int entries = infoMap.size();

--- a/disunity-core/src/main/java/info/ata4/junity/serialize/objectinfo/ObjectInfoV1.java
+++ b/disunity-core/src/main/java/info/ata4/junity/serialize/objectinfo/ObjectInfoV1.java
@@ -18,7 +18,7 @@ import java.io.IOException;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class ObjectInfoV1 extends ObjectInfo {
-    
+
     // set to 1 if the object instance is destroyed?
     // (no longer stored in files starting with Unity 5)
     private short isDestroyed;
@@ -48,5 +48,5 @@ public class ObjectInfoV1 extends ObjectInfo {
         out.writeShort((short) classID);
         out.writeShort(isDestroyed);
     }
-    
+
 }

--- a/disunity-core/src/main/java/info/ata4/junity/serialize/objectinfo/ObjectInfoV2.java
+++ b/disunity-core/src/main/java/info/ata4/junity/serialize/objectinfo/ObjectInfoV2.java
@@ -18,13 +18,13 @@ import java.io.IOException;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class ObjectInfoV2 extends ObjectInfo {
-    
+
     private short scriptTypeIndex;
-    
+
     public short scriptTypeIndex() {
         return scriptTypeIndex;
     }
-    
+
     public void scriptTypeIndex(short scriptTypeIndex) {
         this.scriptTypeIndex = scriptTypeIndex;
     }
@@ -46,5 +46,5 @@ public class ObjectInfoV2 extends ObjectInfo {
         out.writeShort((short) classID);
         out.writeShort(scriptTypeIndex);
     }
-    
+
 }

--- a/disunity-core/src/main/java/info/ata4/junity/serialize/objectinfo/ObjectInfoV3.java
+++ b/disunity-core/src/main/java/info/ata4/junity/serialize/objectinfo/ObjectInfoV3.java
@@ -18,13 +18,13 @@ import java.io.IOException;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class ObjectInfoV3 extends ObjectInfoV2 {
-    
+
     private boolean stripped;
-    
+
     public boolean isStripped() {
         return stripped;
     }
-    
+
     public void setStripped(boolean stripped) {
         this.stripped = stripped;
     }

--- a/disunity-core/src/main/java/info/ata4/junity/serialize/typetree/StringTable.java
+++ b/disunity-core/src/main/java/info/ata4/junity/serialize/typetree/StringTable.java
@@ -28,17 +28,17 @@ import java.util.stream.Collectors;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class StringTable {
-    
+
     private static Map<Integer, Map<Integer, String>> commonStringMap = new HashMap<>();
-    
+
     private StringTable() {
     }
-    
+
     private static BufferedReader resourceReader(String path) {
         return new BufferedReader(new InputStreamReader(
             StringTable.class.getResourceAsStream(path), StandardCharsets.US_ASCII));
     }
-    
+
     public static BiMap<Integer, String> commonStrings(int version) throws IOException {
         // load default strings from resource files if required
         if (!commonStringMap.containsKey(version)) {
@@ -53,13 +53,13 @@ public class StringTable {
                 throw new RuntimeException("No common strings file found for version " + version);
             }
         }
-        
+
         return HashBiMap.create(commonStringMap.get(version));
     }
-    
+
     public static BiMap<Integer, String> read(DataReader in, int length) throws IOException {
         BiMap<Integer, String> map = HashBiMap.create();
-        
+
         // load strings from input
         long startPos = in.position();
         long endPos = startPos + length;

--- a/disunity-core/src/main/java/info/ata4/junity/serialize/typetree/Type.java
+++ b/disunity-core/src/main/java/info/ata4/junity/serialize/typetree/Type.java
@@ -13,35 +13,35 @@ import info.ata4.io.Struct;
 
 /**
  * Class for objects that contain the runtime type of a single field.
- * 
+ *
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  * @unity TypeTree
  */
 public abstract class Type implements Struct {
-    
+
     public static final int FLAG_FORCE_ALIGN = 0x4000;
-    
+
     // field type string
     protected String type;
-    
+
     // field name string
     protected String name;
-    
+
     // size of the field value in bytes or -1 if the field contains sub-fields only
     protected int size;
-    
+
     // field index for the associated parent field
     protected int index;
-    
+
     // set to 1 if "type" is "Array" or "TypelessData"
     protected boolean isArray;
-    
+
     // type version, starts with 1 and is incremented when the type
     // information is updated in a new Unity release
     //
     // equal to serializedVersion in YAML format files
     protected int version;
-    
+
     // field flags
     // observed values:
     // 0x1
@@ -52,7 +52,7 @@ public abstract class Type implements Struct {
     // 0x200000
     // 0x400000
     protected int metaFlag;
-    
+
     public String typeName() {
         return type;
     }
@@ -92,7 +92,7 @@ public abstract class Type implements Struct {
     public void isArray(boolean isArray) {
         this.isArray = isArray;
     }
-    
+
     public int version() {
         return version;
     }
@@ -100,7 +100,7 @@ public abstract class Type implements Struct {
     public void version(int version) {
         this.version = version;
     }
-    
+
     public int metaFlag() {
         return metaFlag;
     }

--- a/disunity-core/src/main/java/info/ata4/junity/serialize/typetree/TypeRoot.java
+++ b/disunity-core/src/main/java/info/ata4/junity/serialize/typetree/TypeRoot.java
@@ -19,7 +19,7 @@ import java.util.Objects;
  * @unity SerializedFile::Type
  */
 public class TypeRoot<T extends Type> {
-    
+
     private int classID;
     private UnityHash128 scriptID;
     private UnityHash128 oldTypeHash;

--- a/disunity-core/src/main/java/info/ata4/junity/serialize/typetree/TypeTree.java
+++ b/disunity-core/src/main/java/info/ata4/junity/serialize/typetree/TypeTree.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 
 /**
  * Class for objects that hold the runtime type information of an asset file.
- * 
+ *
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  * @unity RTTIClassHierarchyDescriptor, RTTIBaseClassDescriptor2, TypeTree
  */
@@ -24,7 +24,7 @@ public abstract class TypeTree<T extends Type> extends UnityStruct<T> {
 
     protected Map<Integer, TypeRoot<T>> typeMap = new LinkedHashMap<>();
     protected boolean embedded;
-    
+
     public TypeTree(Class<T> elementFactory) {
         super(elementFactory);
     }
@@ -32,15 +32,15 @@ public abstract class TypeTree<T extends Type> extends UnityStruct<T> {
     public Map<Integer, TypeRoot<T>> typeMap() {
         return typeMap;
     }
-    
+
     public void typeMap(Map<Integer, TypeRoot<T>> typeMap) {
         this.typeMap = Objects.requireNonNull(typeMap);
     }
-    
+
     public boolean embedded() {
         return embedded;
     }
-    
+
     public void embedded(boolean embedded) {
         this.embedded = embedded;
     }

--- a/disunity-core/src/main/java/info/ata4/junity/serialize/typetree/TypeTreeV1.java
+++ b/disunity-core/src/main/java/info/ata4/junity/serialize/typetree/TypeTreeV1.java
@@ -19,11 +19,11 @@ import java.io.IOException;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class TypeTreeV1<T extends TypeV1> extends TypeTree<T> {
-    
+
     public TypeTreeV1(Class<T> elementFactory) {
         super(elementFactory);
     }
-    
+
     @Override
     public void read(DataReader in) throws IOException {
         int numBaseClasses = in.readInt();
@@ -42,19 +42,19 @@ public class TypeTreeV1<T extends TypeV1> extends TypeTree<T> {
 
         embedded = numBaseClasses > 0;
     }
-    
+
     private void readNode(DataReader in, Node<T> node) throws IOException {
         T type = createElement();
         in.readStruct(type);
-        
+
         node.data(type);
-        
+
         int numChildren = in.readInt();
         for (int i = 0; i < numChildren; i++) {
             Node<T> childNode = new Node<>();
             readNode(in, childNode);
             node.add(childNode);
-        }  
+        }
     }
 
     @Override
@@ -63,8 +63,8 @@ public class TypeTreeV1<T extends TypeV1> extends TypeTree<T> {
         if (!embedded) {
             out.writeInt(0);
             return;
-        }        
-        
+        }
+
         int numBaseClasses = typeMap.size();
         out.writeInt(numBaseClasses);
 
@@ -73,18 +73,18 @@ public class TypeTreeV1<T extends TypeV1> extends TypeTree<T> {
             out.writeInt(classID);
 
             Node<T> node = bc.nodes();
-            
+
             writeNode(out, node);
         }
     }
-    
-    private void writeNode(DataWriter out, Node<T> node) throws IOException {        
+
+    private void writeNode(DataWriter out, Node<T> node) throws IOException {
         T type = node.data();
         out.writeStruct(type);
 
         int numChildren = node.size();
         out.writeInt(numChildren);
-        
+
         for (Node child : node) {
             writeNode(out, child);
         }

--- a/disunity-core/src/main/java/info/ata4/junity/serialize/typetree/TypeTreeV2.java
+++ b/disunity-core/src/main/java/info/ata4/junity/serialize/typetree/TypeTreeV2.java
@@ -20,37 +20,37 @@ import java.util.Objects;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class TypeTreeV2<T extends TypeV1> extends TypeTreeV1<T> {
-    
+
     protected UnityVersion revision = new UnityVersion();
     protected int attributes;
-    
+
     public TypeTreeV2(Class<T> elementFactory) {
         super(elementFactory);
     }
-    
+
     public UnityVersion revision() {
         return revision;
     }
-    
+
     public void revision(UnityVersion revision) {
         this.revision = Objects.requireNonNull(revision);
     }
-    
+
     public int attributes() {
         return attributes;
     }
-    
+
     public void attributes(int attributes) {
         this.attributes = attributes;
     }
-    
+
     @Override
     public void read(DataReader in) throws IOException {
         revision = new UnityVersion(in.readStringNull(255));
         attributes = in.readInt();
-        
+
         super.read(in);
-        
+
         // padding
         in.readInt();
     }
@@ -59,9 +59,9 @@ public class TypeTreeV2<T extends TypeV1> extends TypeTreeV1<T> {
     public void write(DataWriter out) throws IOException {
         out.writeStringNull(revision.toString());
         out.writeInt(attributes);
-        
+
         super.write(out);
-        
+
         // padding
         out.writeInt(0);
     }

--- a/disunity-core/src/main/java/info/ata4/junity/serialize/typetree/TypeV1.java
+++ b/disunity-core/src/main/java/info/ata4/junity/serialize/typetree/TypeV1.java
@@ -18,7 +18,7 @@ import java.io.IOException;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class TypeV1 extends Type {
-    
+
     @Override
     public void read(DataReader in) throws IOException {
         type = in.readStringNull(256);

--- a/disunity-core/src/main/java/info/ata4/junity/serialize/typetree/TypeV2.java
+++ b/disunity-core/src/main/java/info/ata4/junity/serialize/typetree/TypeV2.java
@@ -18,16 +18,16 @@ import java.io.IOException;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class TypeV2 extends TypeV1 {
-    
+
     // Unity 5+, the level of this type within the type tree
     protected int treeLevel;
-    
+
     // Unity 5+, offset to the type string
     protected int typeOffset;
-    
+
     // Unity 5+, offset to the name string
     protected int nameOffset;
-    
+
     public int treeLevel() {
         return treeLevel;
     }
@@ -51,7 +51,7 @@ public class TypeV2 extends TypeV1 {
     public void nameOffset(int nameOffset) {
         this.nameOffset = nameOffset;
     }
-    
+
     @Override
     public void read(DataReader in) throws IOException {
         version = in.readShort();
@@ -63,7 +63,7 @@ public class TypeV2 extends TypeV1 {
         index = in.readInt();
         metaFlag = in.readInt();
     }
-    
+
     @Override
     public void write(DataWriter out) throws IOException {
         out.writeShort((short) version);

--- a/disunity-core/src/main/java/info/ata4/util/collection/Node.java
+++ b/disunity-core/src/main/java/info/ata4/util/collection/Node.java
@@ -25,24 +25,24 @@ import java.util.function.Consumer;
  * @param <T>
  */
 public class Node<T> implements Collection<Node<T>> {
-    
+
     private T data;
     private Node<T> parent;
     private final List<Node<T>> children = new ArrayList<>();
-    
+
     public Node() {
     }
-    
+
     public Node(T data) {
         this.data = data;
     }
-    
+
     public Node(Collection<Node<T>> children) {
         if (children != null) {
             this.children.addAll(children);
         }
     }
-    
+
     public Node(T data, Collection<Node<T>> children) {
         this.data = data;
         if (children != null) {
@@ -53,19 +53,19 @@ public class Node<T> implements Collection<Node<T>> {
     public T data() {
         return data;
     }
-    
+
     public void data(T data) {
         this.data = data;
     }
-    
+
     public Node<T> parent() {
         return parent;
     }
-    
+
     private void parent(Node<T> parent) {
         this.parent = parent;
     }
-    
+
     public void forEachData(Consumer<T> action) {
         Objects.requireNonNull(action);
         action.accept(data());
@@ -91,7 +91,7 @@ public class Node<T> implements Collection<Node<T>> {
     public Iterator<Node<T>> iterator() {
         return Collections.unmodifiableList(children).iterator();
     }
-    
+
     @Override
     public Spliterator<Node<T>> spliterator() {
         return Spliterators.spliterator(Collections.unmodifiableList(children),
@@ -166,7 +166,7 @@ public class Node<T> implements Collection<Node<T>> {
     public void clear() {
         children.clear();
     }
-    
+
     @Override
     public int hashCode() {
         int hash = 5;
@@ -174,7 +174,7 @@ public class Node<T> implements Collection<Node<T>> {
         hash = 43 * hash + Objects.hashCode(this.children);
         return hash;
     }
-    
+
     @Override
     public boolean equals(Object obj) {
         if (obj == null) {

--- a/disunity-core/src/main/java/info/ata4/util/function/IOConsumer.java
+++ b/disunity-core/src/main/java/info/ata4/util/function/IOConsumer.java
@@ -16,14 +16,14 @@ import java.util.function.Consumer;
 /**
  * Interface for consumers that throw IOExceptions, which are wrapped to
  * UncheckedIOExceptions.
- * 
+ *
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 @FunctionalInterface
 public interface IOConsumer<T> {
-    
+
     void accept(T t) throws IOException;
-    
+
     public static <T> Consumer<T> uncheck(IOConsumer<T> consumer) {
         return t -> {
             try {

--- a/disunity-core/src/main/java/info/ata4/util/function/IOFunction.java
+++ b/disunity-core/src/main/java/info/ata4/util/function/IOFunction.java
@@ -16,14 +16,14 @@ import java.util.function.Function;
 /**
  * Interface for functions that throw IOExceptions, which are wrapped to
  * UncheckedIOExceptions.
- * 
+ *
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 @FunctionalInterface
 public interface IOFunction<T, R> {
-    
+
     R apply(T t) throws IOException;
-    
+
     public static <T, R> Function<T, R> uncheck(IOFunction<T, R> function) {
         return t -> {
             try {

--- a/disunity-core/src/main/java/info/ata4/util/function/Predicates.java
+++ b/disunity-core/src/main/java/info/ata4/util/function/Predicates.java
@@ -1,11 +1,11 @@
 /*
-** 2015 December 13
-**
-** The author disclaims copyright to this source code. In place of
-** a legal notice, here is a blessing:
-**    May you do good and not evil.
-**    May you find forgiveness for yourself and forgive others.
-**    May you share freely, never taking more than you give.
+ ** 2015 December 13
+ **
+ ** The author disclaims copyright to this source code. In place of
+ ** a legal notice, here is a blessing:
+ **    May you do good and not evil.
+ **    May you find forgiveness for yourself and forgive others.
+ **    May you share freely, never taking more than you give.
  */
 package info.ata4.util.function;
 
@@ -13,14 +13,14 @@ import java.util.function.Predicate;
 
 /**
  * Small predicate utility class.
- * 
+ *
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class Predicates {
-    
+
     private Predicates() {
     }
-    
+
     public static <T> Predicate<T> not(Predicate<T> t) {
         return t.negate();
     }

--- a/disunity-core/src/main/java/info/ata4/util/io/DataBlock.java
+++ b/disunity-core/src/main/java/info/ata4/util/io/DataBlock.java
@@ -17,7 +17,7 @@ import java.io.IOException;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class DataBlock {
-    
+
     private long offset;
     private long length;
 
@@ -36,31 +36,31 @@ public class DataBlock {
     public void length(long length) {
         this.length = length;
     }
-    
+
     public void endOffset(long endOffset) {
         this.length = endOffset - offset;
     }
-    
+
     public long endOffset() {
         return offset + length;
     }
-    
+
     public boolean isIntersecting(DataBlock that) {
         return this.endOffset() > that.offset() && that.endOffset() > this.offset();
     }
-    
+
     public boolean isInside(DataBlock that) {
         return this.offset() >= that.offset() && this.endOffset() <= that.endOffset();
     }
-    
+
     public void markBegin(Positionable p) throws IOException {
         offset(p.position());
     }
-    
+
     public void markEnd(Positionable p) throws IOException {
         DataBlock.this.endOffset(p.position());
     }
-    
+
     @Override
     public String toString() {
         return DataBlock.this.offset() + " - " + endOffset() + " (" + DataBlock.this.length() + ")";

--- a/disunity-core/src/test/java/info/ata4/test/ParameterizedUtils.java
+++ b/disunity-core/src/test/java/info/ata4/test/ParameterizedUtils.java
@@ -1,11 +1,11 @@
 /*
-** 2015 December 08
-**
-** The author disclaims copyright to this source code. In place of
-** a legal notice, here is a blessing:
-**    May you do good and not evil.
-**    May you find forgiveness for yourself and forgive others.
-**    May you share freely, never taking more than you give.
+ ** 2015 December 08
+ **
+ ** The author disclaims copyright to this source code. In place of
+ ** a legal notice, here is a blessing:
+ **    May you do good and not evil.
+ **    May you find forgiveness for yourself and forgive others.
+ **    May you share freely, never taking more than you give.
  */
 package info.ata4.test;
 
@@ -20,10 +20,10 @@ import java.util.stream.Collectors;
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
 public class ParameterizedUtils {
-    
+
     private ParameterizedUtils() {
     }
-    
+
     public static List<Path[]> getPathParameters(Path dir) throws IOException {
         return Files.walk(dir)
             .filter(Files::isRegularFile)

--- a/disunity-core/src/test/java/info/ata4/test/junity/BundleTest.java
+++ b/disunity-core/src/test/java/info/ata4/test/junity/BundleTest.java
@@ -1,11 +1,11 @@
 /*
-** 2015 December 06
-**
-** The author disclaims copyright to this source code. In place of
-** a legal notice, here is a blessing:
-**    May you do good and not evil.
-**    May you find forgiveness for yourself and forgive others.
-**    May you share freely, never taking more than you give.
+ ** 2015 December 06
+ **
+ ** The author disclaims copyright to this source code. In place of
+ ** a legal notice, here is a blessing:
+ **    May you do good and not evil.
+ **    May you find forgiveness for yourself and forgive others.
+ **    May you share freely, never taking more than you give.
  */
 package info.ata4.test.junity;
 
@@ -37,28 +37,28 @@ import org.junit.runners.Parameterized;
  */
 @RunWith(Parameterized.class)
 public class BundleTest {
-    
+
     @Parameterized.Parameters
     public static List<Path[]> data() throws IOException {
         List<Path[]> params = new ArrayList<>();
-        
+
         // public set
         Path bundleDir = Paths.get("src", "test", "resources", "bundle");
         params.addAll(ParameterizedUtils.getPathParameters(bundleDir));
-        
+
         return params;
     }
-    
+
     private final Path file;
     private Bundle bundle;
     private final BundleReader reader;
-    
+
     public BundleTest(Path file) throws IOException {
         this.file = file;
         this.reader = new BundleReader(file);
         System.out.println(file);
     }
-    
+
     @Before
     public void setUp() throws IOException {
         bundle = reader.read();
@@ -68,42 +68,42 @@ public class BundleTest {
     public void tearDown() throws IOException {
         reader.close();
     }
-    
+
     @Test
     public void headerValid() throws IOException {
         BundleHeader header = bundle.header();
         long fileSize = Files.size(file);
-        
+
         assertTrue("Number of levels to download must be equal to number of levels or 1",
                 header.numberOfLevelsToDownload() == header.numberOfLevels() || header.numberOfLevelsToDownload() == 1);
-        
+
         assertTrue("Signatures should be valid", header.hasValidSignature());
-        
+
         assertTrue("Minimum streamed bytes must be smaller than or equal to file size",
                 header.minimumStreamedBytes() <= fileSize);
-        
+
         assertTrue("Header size must be smaller than file size",
                 header.headerSize() < fileSize);
-        
+
         if (header.streamVersion() >= 2) {
             assertEquals("Header file size and actual file size must be equal",
                     header.completeFileSize(), fileSize);
         }
-        
+
         assertEquals("Number of levels must match number of level end offsets",
                 header.numberOfLevelsToDownload(), header.levelByteEnd().size());
-        
+
         header.levelByteEnd().forEach(lbe -> {
             assertTrue("Compressed offset must be smaller or equal to uncompressed offset",
                     lbe.getLeft() <= lbe.getRight());
         });
     }
-    
+
     @Test
     public void entriesValid() {
         assertEquals("Bundle entry lists must match in size",
                 bundle.entries().size(), bundle.entryInfos().size());
-        
+
         bundle.entries().forEach(uncheck(entry -> {
             CountingOutputStream cos = new CountingOutputStream(new NullOutputStream());
             IOUtils.copy(entry.inputStream(), cos);

--- a/disunity-core/src/test/java/info/ata4/test/junity/SerializedFileTest.java
+++ b/disunity-core/src/test/java/info/ata4/test/junity/SerializedFileTest.java
@@ -1,11 +1,11 @@
 /*
-** 2015 December 02
-**
-** The author disclaims copyright to this source code. In place of
-** a legal notice, here is a blessing:
-**    May you do good and not evil.
-**    May you find forgiveness for yourself and forgive others.
-**    May you share freely, never taking more than you give.
+ ** 2015 December 02
+ **
+ ** The author disclaims copyright to this source code. In place of
+ ** a legal notice, here is a blessing:
+ **    May you do good and not evil.
+ **    May you find forgiveness for yourself and forgive others.
+ **    May you share freely, never taking more than you give.
  */
 package info.ata4.test.junity;
 
@@ -41,22 +41,22 @@ import static org.junit.Assert.assertTrue;
  */
 @RunWith(Parameterized.class)
 public class SerializedFileTest {
-    
+
     @Parameterized.Parameters
     public static List<Path[]> data() throws IOException {
         List<Path[]> params = new ArrayList<>();
-        
+
         // public set
         Path mainDataDirPublic = Paths.get("src", "test", "resources", "mainData");
         params.addAll(ParameterizedUtils.getPathParameters(mainDataDirPublic));
-        
+
         // private set (files that are too large or proprietary)
         //Path mainDataDirPrivate = Paths.get("..", "private", "test", "mainData");
         //params.addAll(ParameterizedUtils.getPathParameters(mainDataDirPrivate));
-        
+
         return params;
     }
-    
+
     private final Path readFile;
     private SerializedFile asset;
 
@@ -64,29 +64,29 @@ public class SerializedFileTest {
         this.readFile = file;
         System.out.println(file);
     }
-    
+
     @Before
     public void setUp() throws IOException {
         try (SerializedFileReader assetReader = new SerializedFileReader(readFile)) {
             asset = assetReader.read();
         }
     }
-    
+
     @Test
     public void offsetsAndSizesValid() throws IOException {
         SerializedFileHeader header = asset.header();
-        
+
         long fileSize = Files.size(readFile);
         assertEquals("Header file size and actual file size must be equal",
                 header.fileSize(), fileSize);
-        
+
         assertTrue("Data offset must be within file",
                 header.dataOffset() < header.fileSize());
-        
+
         // allowing a difference of 3 bytes because of padding
         assertEquals("Metadata sizes in data block and header must match",
                 header.metadataSize(), asset.metadataBlock().length(), 3);
-        
+
         // check blocks
         List<DataBlock> blocks = asset.dataBlocks();
         blocks.forEach(block1 -> blocks.forEach(block2 -> {
@@ -96,7 +96,7 @@ public class SerializedFileTest {
             }
         }));
     }
-    
+
     @Test
     public void objectInfoValid() throws IOException {
         asset.metadata().objectInfoTable().infoMap().forEach((path, objectInfo) -> {
@@ -109,7 +109,7 @@ public class SerializedFileTest {
                     (objectInfo.classID() == 114 && objectInfo.typeID() < 0));
         });
     }
-    
+
     @Test
     public void typeTreeValid() {
         if (asset.metadata().typeTree().embedded()) {
@@ -126,7 +126,7 @@ public class SerializedFileTest {
             });
         }
     }
-    
+
     @Test
     public void directCopyMatches() throws IOException {
         Path writeFile = Files.createTempFile("writeTest", ".assets");
@@ -135,7 +135,7 @@ public class SerializedFileTest {
                     DataWriters.forFile(writeFile, WRITE))) {
                 writer.write(asset);
             }
-            
+
             assertEquals("Output file must match input file",
                     FileUtils.checksumCRC32(readFile.toFile()),
                     FileUtils.checksumCRC32(writeFile.toFile()));


### PR DESCRIPTION
- Removed trailing whitespace
- Fixed legal notice formatting inconsistency

Trailing whitespace, on top of being a bad practice, slow down vertical movement in editors such as vim which use blank lines as jump markers.