### PR TITLE
Prototype UnityFS bundle reader support

### DIFF
--- a/disunity-cli/src/main/java/info/ata4/disunity/cli/command/bundle/BundleUnpack.java
+++ b/disunity-cli/src/main/java/info/ata4/disunity/cli/command/bundle/BundleUnpack.java
@@ -23,6 +23,8 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
+import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
@@ -72,6 +74,10 @@ public class BundleUnpack extends FileCommand {
                 // with sub-directories
                 if (bundle.entryInfos().size() == 1) {
                     outputDir = file.getParent();
+                    if (outputDir == null) {
+                        // Passed a filename only. Use the current directory.
+                        outputDir = Paths.get(".");
+                    }
                 } else {
                     String fileName = PathUtils.getBaseName(file);
                     outputDir = file.resolveSibling(fileName);

--- a/disunity-core/src/main/java/info/ata4/junity/bundle/BundleEntryInfoFS.java
+++ b/disunity-core/src/main/java/info/ata4/junity/bundle/BundleEntryInfoFS.java
@@ -1,0 +1,49 @@
+/*
+ ** 2014 September 25
+ **
+ ** The author disclaims copyright to this source code. In place of
+ ** a legal notice, here is a blessing:
+ **    May you do good and not evil.
+ **    May you find forgiveness for yourself and forgive others.
+ **    May you share freely, never taking more than you give.
+ */
+package info.ata4.junity.bundle;
+
+import info.ata4.io.DataReader;
+import info.ata4.io.DataWriter;
+
+import java.io.IOException;
+
+/**
+ * UnityFS-format bundle entry info
+ */
+public class BundleEntryInfoFS extends BundleEntryInfo {
+
+    // unknown extra field, guessing flags
+    private long flags;
+
+    public long flags() { return flags; };
+
+    public void flags(long flags) { this.flags = flags; }
+
+    @Override
+    public void read(DataReader in) throws IOException {
+        offset(in.readLong());
+        size(in.readLong());
+        flags = in.readUnsignedInt();
+        name(in.readStringNull());
+    }
+
+    @Override
+    public void write(DataWriter out) throws IOException {
+        out.writeLong(offset());
+        out.writeLong(size());
+        out.writeUnsignedInt(flags);
+        out.writeStringNull(name());
+    }
+
+    @Override
+    public String toString() {
+        return name();
+    }
+}

--- a/disunity-core/src/main/java/info/ata4/util/lz4/ByteBufferUtils.java
+++ b/disunity-core/src/main/java/info/ata4/util/lz4/ByteBufferUtils.java
@@ -1,0 +1,94 @@
+/* Partial import of https://github.com/jpountz/lz4-java, Apache 2.0 licensed. */
+
+package info.ata4.util.lz4;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.ReadOnlyBufferException;
+
+public enum ByteBufferUtils {
+  ;
+
+  public static void checkRange(ByteBuffer buf, int off, int len) {
+    SafeUtils.checkLength(len);
+    if (len > 0) {
+      checkRange(buf, off);
+      checkRange(buf, off + len - 1);
+    }
+  }
+
+  public static void checkRange(ByteBuffer buf, int off) {
+    if (off < 0 || off >= buf.capacity()) {
+      throw new ArrayIndexOutOfBoundsException(off);
+    }
+  }
+
+  public static ByteBuffer inLittleEndianOrder(ByteBuffer buf) {
+    if (buf.order().equals(ByteOrder.LITTLE_ENDIAN)) {
+      return buf;
+    } else {
+      return buf.duplicate().order(ByteOrder.LITTLE_ENDIAN);
+    }
+  }
+
+  public static ByteBuffer inNativeByteOrder(ByteBuffer buf) {
+    if (buf.order().equals(Utils.NATIVE_BYTE_ORDER)) {
+      return buf;
+    } else {
+      return buf.duplicate().order(Utils.NATIVE_BYTE_ORDER);
+    }
+  }
+
+  public static byte readByte(ByteBuffer buf, int i) {
+    return buf.get(i);
+  }
+
+  public static void writeInt(ByteBuffer buf, int i, int v) {
+    assert buf.order() == Utils.NATIVE_BYTE_ORDER;
+    buf.putInt(i, v);
+  }
+
+  public static int readInt(ByteBuffer buf, int i) {
+    assert buf.order() == Utils.NATIVE_BYTE_ORDER;
+    return buf.getInt(i);
+  }
+
+  public static int readIntLE(ByteBuffer buf, int i) {
+    assert buf.order() == ByteOrder.LITTLE_ENDIAN;
+    return buf.getInt(i);
+  }
+
+  public static void writeLong(ByteBuffer buf, int i, long v) {
+    assert buf.order() == Utils.NATIVE_BYTE_ORDER;
+    buf.putLong(i, v);
+  }
+
+  public static long readLong(ByteBuffer buf, int i) {
+    assert buf.order() == Utils.NATIVE_BYTE_ORDER;
+    return buf.getLong(i);
+  }
+
+  public static long readLongLE(ByteBuffer buf, int i) {
+    assert buf.order() == ByteOrder.LITTLE_ENDIAN;
+    return buf.getLong(i);
+  }
+
+  public static void writeByte(ByteBuffer dest, int off, int i) {
+    dest.put(off, (byte) i);
+  }
+
+  public static void writeShortLE(ByteBuffer dest, int off, int i) {
+    dest.put(off, (byte) i);
+    dest.put(off + 1, (byte) (i >>> 8));
+  }
+
+  public static void checkNotReadOnly(ByteBuffer buffer) {
+    if (buffer.isReadOnly()) {
+      throw new ReadOnlyBufferException();
+    }
+  }
+
+  public static int readShortLE(ByteBuffer buf, int i) {
+    return (buf.get(i) & 0xFF) | ((buf.get(i+1) & 0xFF) << 8);
+  }
+}

--- a/disunity-core/src/main/java/info/ata4/util/lz4/LZ4ByteBufferUtils.java
+++ b/disunity-core/src/main/java/info/ata4/util/lz4/LZ4ByteBufferUtils.java
@@ -1,0 +1,239 @@
+/* Partial import of https://github.com/jpountz/lz4-java, Apache 2.0 licensed. */
+
+package info.ata4.util.lz4;
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static info.ata4.util.lz4.LZ4Constants.COPY_LENGTH;
+import static info.ata4.util.lz4.LZ4Constants.LAST_LITERALS;
+import static info.ata4.util.lz4.LZ4Constants.ML_BITS;
+import static info.ata4.util.lz4.LZ4Constants.ML_MASK;
+import static info.ata4.util.lz4.LZ4Constants.RUN_MASK;
+import static info.ata4.util.lz4.ByteBufferUtils.readByte;
+import static info.ata4.util.lz4.ByteBufferUtils.readInt;
+import static info.ata4.util.lz4.ByteBufferUtils.readLong;
+import static info.ata4.util.lz4.ByteBufferUtils.writeByte;
+import static info.ata4.util.lz4.ByteBufferUtils.writeInt;
+import static info.ata4.util.lz4.ByteBufferUtils.writeLong;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+enum LZ4ByteBufferUtils {
+  ;
+  static int hash(ByteBuffer buf, int i) {
+    return LZ4Utils.hash(readInt(buf, i));
+  }
+
+  static int hash64k(ByteBuffer buf, int i) {
+    return LZ4Utils.hash64k(readInt(buf, i));
+  }
+
+  static boolean readIntEquals(ByteBuffer buf, int i, int j) {
+    return buf.getInt(i) == buf.getInt(j);
+  }
+
+  static void safeIncrementalCopy(ByteBuffer dest, int matchOff, int dOff, int matchLen) {
+    for (int i = 0; i < matchLen; ++i) {
+      dest.put(dOff + i, dest.get(matchOff + i));
+    }
+  }
+
+  static void wildIncrementalCopy(ByteBuffer dest, int matchOff, int dOff, int matchCopyEnd) {
+    if (dOff - matchOff < 4) {
+      for (int i = 0; i < 4; ++i) {
+        writeByte(dest, dOff+i, readByte(dest, matchOff+i));
+      }
+      dOff += 4;
+      matchOff += 4;
+      int dec = 0;
+      assert dOff >= matchOff && dOff - matchOff < 8;
+      switch (dOff - matchOff) {
+      case 1:
+        matchOff -= 3;
+        break;
+      case 2:
+        matchOff -= 2;
+        break;
+      case 3:
+        matchOff -= 3;
+        dec = -1;
+        break;
+      case 5:
+        dec = 1;
+        break;
+      case 6:
+        dec = 2;
+        break;
+      case 7:
+        dec = 3;
+        break;
+      default:
+        break;
+      }
+      writeInt(dest, dOff, readInt(dest, matchOff));
+      dOff += 4;
+      matchOff -= dec;
+    } else if (dOff - matchOff < COPY_LENGTH) {
+      writeLong(dest, dOff, readLong(dest, matchOff));
+      dOff += dOff - matchOff;
+    }
+    while (dOff < matchCopyEnd) {
+      writeLong(dest, dOff, readLong(dest, matchOff));
+      dOff += 8;
+      matchOff += 8;
+    }
+  }
+
+  static int commonBytes(ByteBuffer src, int ref, int sOff, int srcLimit) {
+    int matchLen = 0;
+    while (sOff <= srcLimit - 8) {
+      if (readLong(src, sOff) == readLong(src, ref)) {
+        matchLen += 8;
+        ref += 8;
+        sOff += 8;
+      } else {
+        final int zeroBits;
+        if (src.order() == ByteOrder.BIG_ENDIAN) {
+          zeroBits = Long.numberOfLeadingZeros(readLong(src, sOff) ^ readLong(src, ref));
+        } else {
+          zeroBits = Long.numberOfTrailingZeros(readLong(src, sOff) ^ readLong(src, ref));
+        }
+        return matchLen + (zeroBits >>> 3);
+      }
+    }
+    while (sOff < srcLimit && readByte(src, ref++) == readByte(src, sOff++)) {
+      ++matchLen;
+    }
+    return matchLen;
+  }
+
+  static int commonBytesBackward(ByteBuffer b, int o1, int o2, int l1, int l2) {
+    int count = 0;
+    while (o1 > l1 && o2 > l2 && b.get(--o1) == b.get(--o2)) {
+      ++count;
+    }
+    return count;
+  }
+
+  static void safeArraycopy(ByteBuffer src, int sOff, ByteBuffer dest, int dOff, int len) {
+    for (int i = 0; i < len; ++i) {
+      dest.put(dOff + i, src.get(sOff + i));
+    }
+  }
+
+  static void wildArraycopy(ByteBuffer src, int sOff, ByteBuffer dest, int dOff, int len) {
+    assert src.order().equals(dest.order());
+    try {
+      for (int i = 0; i < len; i += 8) {
+        dest.putLong(dOff + i, src.getLong(sOff + i));
+      }
+    } catch (IndexOutOfBoundsException e) {
+      throw new LZ4Exception("Malformed input at offset " + sOff);
+    }
+  }
+
+  static int encodeSequence(ByteBuffer src, int anchor, int matchOff, int matchRef, int matchLen, ByteBuffer dest, int dOff, int destEnd) {
+    final int runLen = matchOff - anchor;
+    final int tokenOff = dOff++;
+
+    if (dOff + runLen + (2 + 1 + LAST_LITERALS) + (runLen >>> 8) > destEnd) {
+      throw new LZ4Exception("maxDestLen is too small");
+    }
+
+    int token;
+    if (runLen >= RUN_MASK) {
+      token = (byte) (RUN_MASK << ML_BITS);
+      dOff = writeLen(runLen - RUN_MASK, dest, dOff);
+    } else {
+      token = runLen << ML_BITS;
+    }
+
+    // copy literals
+    wildArraycopy(src, anchor, dest, dOff, runLen);
+    dOff += runLen;
+
+    // encode offset
+    final int matchDec = matchOff - matchRef;
+    dest.put(dOff++, (byte) matchDec);
+    dest.put(dOff++, (byte) (matchDec >>> 8));
+
+    // encode match len
+    matchLen -= 4;
+    if (dOff + (1 + LAST_LITERALS) + (matchLen >>> 8) > destEnd) {
+      throw new LZ4Exception("maxDestLen is too small");
+    }
+    if (matchLen >= ML_MASK) {
+      token |= ML_MASK;
+      dOff = writeLen(matchLen - RUN_MASK, dest, dOff);
+    } else {
+      token |= matchLen;
+    }
+
+    dest.put(tokenOff, (byte) token);
+
+    return dOff;
+  }
+
+  static int lastLiterals(ByteBuffer src, int sOff, int srcLen, ByteBuffer dest, int dOff, int destEnd) {
+    final int runLen = srcLen;
+
+    if (dOff + runLen + 1 + (runLen + 255 - RUN_MASK) / 255 > destEnd) {
+      throw new LZ4Exception();
+    }
+
+    if (runLen >= RUN_MASK) {
+      dest.put(dOff++, (byte) (RUN_MASK << ML_BITS));
+      dOff = writeLen(runLen - RUN_MASK, dest, dOff);
+    } else {
+      dest.put(dOff++, (byte) (runLen << ML_BITS));
+    }
+    // copy literals
+    safeArraycopy(src, sOff, dest, dOff, runLen);
+    dOff += runLen;
+
+    return dOff;
+  }
+
+  static int writeLen(int len, ByteBuffer dest, int dOff) {
+    while (len >= 0xFF) {
+      dest.put(dOff++, (byte) 0xFF);
+      len -= 0xFF;
+    }
+    dest.put(dOff++, (byte) len);
+    return dOff;
+  }
+
+  static class Match {
+    int start, ref, len;
+
+    void fix(int correction) {
+      start += correction;
+      ref += correction;
+      len -= correction;
+    }
+
+    int end() {
+      return start + len;
+    }
+  }
+
+  static void copyTo(Match m1, Match m2) {
+    m2.len = m1.len;
+    m2.start = m1.start;
+    m2.ref = m1.ref;
+  }
+
+}

--- a/disunity-core/src/main/java/info/ata4/util/lz4/LZ4Constants.java
+++ b/disunity-core/src/main/java/info/ata4/util/lz4/LZ4Constants.java
@@ -1,0 +1,55 @@
+/* Partial import of https://github.com/jpountz/lz4-java, Apache 2.0 licensed. */
+
+package info.ata4.util.lz4;
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+enum LZ4Constants {
+  ;
+
+  static final int DEFAULT_COMPRESSION_LEVEL = 8+1;
+  static final int MAX_COMPRESSION_LEVEL = 16+1;
+
+  static final int MEMORY_USAGE = 14;
+  static final int NOT_COMPRESSIBLE_DETECTION_LEVEL = 6;
+
+  static final int MIN_MATCH = 4;
+
+  static final int HASH_LOG = MEMORY_USAGE - 2;
+  static final int HASH_TABLE_SIZE = 1 << HASH_LOG;
+
+  static final int SKIP_STRENGTH = Math.max(NOT_COMPRESSIBLE_DETECTION_LEVEL, 2);
+  static final int COPY_LENGTH = 8;
+  static final int LAST_LITERALS = 5;
+  static final int MF_LIMIT = COPY_LENGTH + MIN_MATCH;
+  static final int MIN_LENGTH = MF_LIMIT + 1;
+
+  static final int MAX_DISTANCE = 1 << 16;
+
+  static final int ML_BITS = 4;
+  static final int ML_MASK = (1 << ML_BITS) - 1;
+  static final int RUN_BITS = 8 - ML_BITS;
+  static final int RUN_MASK = (1 << RUN_BITS) - 1;
+
+  static final int LZ4_64K_LIMIT = (1 << 16) + (MF_LIMIT - 1);
+  static final int HASH_LOG_64K = HASH_LOG + 1;
+  static final int HASH_TABLE_SIZE_64K = 1 << HASH_LOG_64K;
+
+  static final int HASH_LOG_HC = 15;
+  static final int HASH_TABLE_SIZE_HC = 1 << HASH_LOG_HC;
+  static final int OPTIMAL_ML = ML_MASK - 1 + MIN_MATCH;
+
+}

--- a/disunity-core/src/main/java/info/ata4/util/lz4/LZ4Exception.java
+++ b/disunity-core/src/main/java/info/ata4/util/lz4/LZ4Exception.java
@@ -1,0 +1,38 @@
+/* Partial import of https://github.com/jpountz/lz4-java, Apache 2.0 licensed. */
+
+package info.ata4.util.lz4;
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * LZ4 compression or decompression error.
+ */
+public class LZ4Exception extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  public LZ4Exception(String msg, Throwable t) {
+    super(msg, t);
+  }
+
+  public LZ4Exception(String msg) {
+    super(msg);
+  }
+
+  public LZ4Exception() {
+    super();
+  }
+
+}

--- a/disunity-core/src/main/java/info/ata4/util/lz4/LZ4FastDecompressor.java
+++ b/disunity-core/src/main/java/info/ata4/util/lz4/LZ4FastDecompressor.java
@@ -1,0 +1,108 @@
+package info.ata4.util.lz4;
+
+/* Partial import of https://github.com/jpountz/lz4-java, Apache 2.0 licensed. */
+
+import java.nio.ByteBuffer;
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * LZ4 decompressor that requires the size of the original input to be known.
+ * Use LZ4SafeDecompressor if you only know the size of the
+ * compressed stream.
+ * <p>
+ * Instances of this class are thread-safe.
+ */
+public abstract class LZ4FastDecompressor {
+
+  /** Decompress <code>src[srcOff:]</code> into <code>dest[destOff:destOff+destLen]</code>
+   * and return the number of bytes read from <code>src</code>.
+   * <code>destLen</code> must be exactly the size of the decompressed data.
+   *
+   * @param destLen the <b>exact</b> size of the original input
+   * @return the number of bytes read to restore the original input
+   */
+  public abstract int decompress(byte[] src, int srcOff, byte[] dest, int destOff, int destLen);
+
+  /** Decompress <code>src[srcOff:]</code> into <code>dest[destOff:destOff+destLen]</code>
+   * and return the number of bytes read from <code>src</code>.
+   * <code>destLen</code> must be exactly the size of the decompressed data.
+   * The positions and limits of the {@link ByteBuffer}s remain unchanged.
+   *
+   * @param destLen the <b>exact</b> size of the original input
+   * @return the number of bytes read to restore the original input
+   */
+  public abstract int decompress(ByteBuffer src, int srcOff, ByteBuffer dest, int destOff, int destLen);
+
+  /**
+   * Convenience method, equivalent to calling
+   * {@link #decompress(byte[], int, byte[], int, int) decompress(src, 0, dest, 0, destLen)}.
+   */
+  public final int decompress(byte[] src, byte[] dest, int destLen) {
+    return decompress(src, 0, dest, 0, destLen);
+  }
+
+  /**
+   * Convenience method, equivalent to calling
+   * {@link #decompress(byte[], byte[], int) decompress(src, dest, dest.length)}.
+   */
+  public final int decompress(byte[] src, byte[] dest) {
+    return decompress(src, dest, dest.length);
+  }
+
+  /**
+   * Convenience method which returns <code>src[srcOff:?]</code>
+   * decompressed.
+   * <p><b><span style="color:red">Warning</span></b>: this method has an
+   * important overhead due to the fact that it needs to allocate a buffer to
+   * decompress into.</p>
+   * <p>Here is how this method is implemented:</p>
+   * <pre>
+   * final byte[] decompressed = new byte[destLen];
+   * decompress(src, srcOff, decompressed, 0, destLen);
+   * return decompressed;
+   * </pre>
+   */
+  public final byte[] decompress(byte[] src, int srcOff, int destLen) {
+    final byte[] decompressed = new byte[destLen];
+    decompress(src, srcOff, decompressed, 0, destLen);
+    return decompressed;
+  }
+
+  /**
+   * Convenience method, equivalent to calling
+   * {@link #decompress(byte[], int, int) decompress(src, 0, destLen)}.
+   */
+  public final byte[] decompress(byte[] src, int destLen) {
+    return decompress(src, 0, destLen);
+  }
+
+  /**
+   * Decompress <code>src</code> into <code>dest</code>. <code>dest</code>'s
+   * {@link ByteBuffer#remaining()} must be exactly the size of the decompressed
+   * data. This method moves the positions of the buffers.
+   */
+  public final void decompress(ByteBuffer src, ByteBuffer dest) {
+    final int read = decompress(src, src.position(), dest, dest.position(), dest.remaining());
+    dest.position(dest.limit());
+    src.position(src.position() + read);
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName();
+  }
+
+}

--- a/disunity-core/src/main/java/info/ata4/util/lz4/LZ4JavaSafeFastDecompressor.java
+++ b/disunity-core/src/main/java/info/ata4/util/lz4/LZ4JavaSafeFastDecompressor.java
@@ -1,0 +1,205 @@
+/* Partial import of https://github.com/jpountz/lz4-java, Apache 2.0 licensed. */
+
+package info.ata4.util.lz4;
+
+import static info.ata4.util.lz4.LZ4Constants.*;
+
+import java.nio.ByteBuffer;
+
+import info.ata4.util.lz4.ByteBufferUtils;
+import info.ata4.util.lz4.SafeUtils;
+
+/**
+ * Decompressor.
+ */
+public final class LZ4JavaSafeFastDecompressor extends LZ4FastDecompressor {
+
+  public static final LZ4FastDecompressor INSTANCE = new LZ4JavaSafeFastDecompressor();
+
+  @Override
+  public int decompress(byte[] src, final int srcOff, byte[] dest, final int destOff, int destLen) {
+
+
+    SafeUtils.checkRange(src, srcOff);
+    SafeUtils.checkRange(dest, destOff, destLen);
+
+    if (destLen == 0) {
+      if (SafeUtils.readByte(src, srcOff) != 0) {
+        throw new LZ4Exception("Malformed input at " + srcOff);
+      }
+      return 1;
+    }
+
+
+    final int destEnd = destOff + destLen;
+
+    int sOff = srcOff;
+    int dOff = destOff;
+
+    while (true) {
+      final int token = SafeUtils.readByte(src, sOff) & 0xFF;
+      ++sOff;
+
+      // literals
+      int literalLen = token >>> ML_BITS;
+      if (literalLen == RUN_MASK) {
+        byte len = (byte) 0xFF;
+        while ((len = SafeUtils.readByte(src, sOff++)) == (byte) 0xFF) {
+          literalLen += 0xFF;
+        }
+        literalLen += len & 0xFF;
+      }
+
+      final int literalCopyEnd = dOff + literalLen;
+
+      if (literalCopyEnd > destEnd - COPY_LENGTH) {
+        if (literalCopyEnd != destEnd) {
+          throw new LZ4Exception("Malformed input at " + sOff);
+
+        } else {
+          LZ4SafeUtils.safeArraycopy(src, sOff, dest, dOff, literalLen);
+          sOff += literalLen;
+          dOff = literalCopyEnd;
+          break; // EOF
+        }
+      }
+
+      LZ4SafeUtils.wildArraycopy(src, sOff, dest, dOff, literalLen);
+      sOff += literalLen;
+      dOff = literalCopyEnd;
+
+      // matchs
+      final int matchDec = SafeUtils.readShortLE(src, sOff);
+      sOff += 2;
+      int matchOff = dOff - matchDec;
+
+      if (matchOff < destOff) {
+        throw new LZ4Exception("Malformed input at " + sOff);
+      }
+
+      int matchLen = token & ML_MASK;
+      if (matchLen == ML_MASK) {
+        byte len = (byte) 0xFF;
+        while ((len = SafeUtils.readByte(src, sOff++)) == (byte) 0xFF) {
+          matchLen += 0xFF;
+        }
+        matchLen += len & 0xFF;
+      }
+      matchLen += MIN_MATCH;
+
+      final int matchCopyEnd = dOff + matchLen;
+
+      if (matchCopyEnd > destEnd - COPY_LENGTH) {
+        if (matchCopyEnd > destEnd) {
+          throw new LZ4Exception("Malformed input at " + sOff);
+        }
+        LZ4SafeUtils.safeIncrementalCopy(dest, matchOff, dOff, matchLen);
+      } else {
+        LZ4SafeUtils.wildIncrementalCopy(dest, matchOff, dOff, matchCopyEnd);
+      }
+      dOff = matchCopyEnd;
+    }
+
+
+    return sOff - srcOff;
+
+  }
+
+  @Override
+  public int decompress(ByteBuffer src, final int srcOff, ByteBuffer dest, final int destOff, int destLen) {
+
+    if (src.hasArray() && dest.hasArray()) {
+      return decompress(src.array(), srcOff + src.arrayOffset(), dest.array(), destOff + dest.arrayOffset(), destLen);
+    }
+    src = ByteBufferUtils.inNativeByteOrder(src);
+    dest = ByteBufferUtils.inNativeByteOrder(dest);
+
+
+    ByteBufferUtils.checkRange(src, srcOff);
+    ByteBufferUtils.checkRange(dest, destOff, destLen);
+
+    if (destLen == 0) {
+      if (ByteBufferUtils.readByte(src, srcOff) != 0) {
+        throw new LZ4Exception("Malformed input at " + srcOff);
+      }
+      return 1;
+    }
+
+
+    final int destEnd = destOff + destLen;
+
+    int sOff = srcOff;
+    int dOff = destOff;
+
+    while (true) {
+      final int token = ByteBufferUtils.readByte(src, sOff) & 0xFF;
+      ++sOff;
+
+      // literals
+      int literalLen = token >>> ML_BITS;
+      if (literalLen == RUN_MASK) {
+        byte len = (byte) 0xFF;
+        while ((len = ByteBufferUtils.readByte(src, sOff++)) == (byte) 0xFF) {
+          literalLen += 0xFF;
+        }
+        literalLen += len & 0xFF;
+      }
+
+      final int literalCopyEnd = dOff + literalLen;
+
+      if (literalCopyEnd > destEnd - COPY_LENGTH) {
+        if (literalCopyEnd != destEnd) {
+          throw new LZ4Exception("Malformed input at " + sOff);
+
+        } else {
+          LZ4ByteBufferUtils.safeArraycopy(src, sOff, dest, dOff, literalLen);
+          sOff += literalLen;
+          dOff = literalCopyEnd;
+          break; // EOF
+        }
+      }
+
+      LZ4ByteBufferUtils.wildArraycopy(src, sOff, dest, dOff, literalLen);
+      sOff += literalLen;
+      dOff = literalCopyEnd;
+
+      // matchs
+      final int matchDec = ByteBufferUtils.readShortLE(src, sOff);
+      sOff += 2;
+      int matchOff = dOff - matchDec;
+
+      if (matchOff < destOff) {
+        throw new LZ4Exception("Malformed input at " + sOff);
+      }
+
+      int matchLen = token & ML_MASK;
+      if (matchLen == ML_MASK) {
+        byte len = (byte) 0xFF;
+        while ((len = ByteBufferUtils.readByte(src, sOff++)) == (byte) 0xFF) {
+          matchLen += 0xFF;
+        }
+        matchLen += len & 0xFF;
+      }
+      matchLen += MIN_MATCH;
+
+      final int matchCopyEnd = dOff + matchLen;
+
+      if (matchCopyEnd > destEnd - COPY_LENGTH) {
+        if (matchCopyEnd > destEnd) {
+          throw new LZ4Exception("Malformed input at " + sOff);
+        }
+        LZ4ByteBufferUtils.safeIncrementalCopy(dest, matchOff, dOff, matchLen);
+      } else {
+        LZ4ByteBufferUtils.wildIncrementalCopy(dest, matchOff, dOff, matchCopyEnd);
+      }
+      dOff = matchCopyEnd;
+    }
+
+
+    return sOff - srcOff;
+
+  }
+
+
+}
+

--- a/disunity-core/src/main/java/info/ata4/util/lz4/LZ4SafeUtils.java
+++ b/disunity-core/src/main/java/info/ata4/util/lz4/LZ4SafeUtils.java
@@ -1,0 +1,180 @@
+/* Partial import of https://github.com/jpountz/lz4-java, Apache 2.0 licensed. */
+
+package info.ata4.util.lz4;
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static info.ata4.util.lz4.LZ4Constants.LAST_LITERALS;
+import static info.ata4.util.lz4.LZ4Constants.ML_BITS;
+import static info.ata4.util.lz4.LZ4Constants.ML_MASK;
+import static info.ata4.util.lz4.LZ4Constants.RUN_MASK;
+
+enum LZ4SafeUtils {
+  ;
+
+  static int hash(byte[] buf, int i) {
+    return LZ4Utils.hash(SafeUtils.readInt(buf, i));
+  }
+
+  static int hash64k(byte[] buf, int i) {
+    return LZ4Utils.hash64k(SafeUtils.readInt(buf, i));
+  }
+
+  static boolean readIntEquals(byte[] buf, int i, int j) {
+    return buf[i] == buf[j] && buf[i+1] == buf[j+1] && buf[i+2] == buf[j+2] && buf[i+3] == buf[j+3];
+  }
+
+  static void safeIncrementalCopy(byte[] dest, int matchOff, int dOff, int matchLen) {
+    for (int i = 0; i < matchLen; ++i) {
+      dest[dOff + i] = dest[matchOff + i];
+    }
+  }
+
+  static void wildIncrementalCopy(byte[] dest, int matchOff, int dOff, int matchCopyEnd) {
+    do {
+      copy8Bytes(dest, matchOff, dest, dOff);
+      matchOff += 8;
+      dOff += 8;
+    } while (dOff < matchCopyEnd);
+  }
+
+  static void copy8Bytes(byte[] src, int sOff, byte[] dest, int dOff) {
+    for (int i = 0; i < 8; ++i) {
+      dest[dOff + i] = src[sOff + i];
+    }
+  }
+
+  static int commonBytes(byte[] b, int o1, int o2, int limit) {
+    int count = 0;
+    while (o2 < limit && b[o1++] == b[o2++]) {
+      ++count;
+    }
+    return count;
+  }
+
+  static int commonBytesBackward(byte[] b, int o1, int o2, int l1, int l2) {
+    int count = 0;
+    while (o1 > l1 && o2 > l2 && b[--o1] == b[--o2]) {
+      ++count;
+    }
+    return count;
+  }
+
+  static void safeArraycopy(byte[] src, int sOff, byte[] dest, int dOff, int len) {
+    System.arraycopy(src, sOff, dest, dOff, len);
+  }
+
+  static void wildArraycopy(byte[] src, int sOff, byte[] dest, int dOff, int len) {
+    try {
+      for (int i = 0; i < len; i += 8) {
+        copy8Bytes(src, sOff + i, dest, dOff + i);
+      }
+    } catch (ArrayIndexOutOfBoundsException e) {
+      throw new LZ4Exception("Malformed input at offset " + sOff);
+    }
+  }
+
+  static int encodeSequence(byte[] src, int anchor, int matchOff, int matchRef, int matchLen, byte[] dest, int dOff, int destEnd) {
+    final int runLen = matchOff - anchor;
+    final int tokenOff = dOff++;
+
+    if (dOff + runLen + (2 + 1 + LAST_LITERALS) + (runLen >>> 8) > destEnd) {
+      throw new LZ4Exception("maxDestLen is too small");
+    }
+
+    int token;
+    if (runLen >= RUN_MASK) {
+      token = (byte) (RUN_MASK << ML_BITS);
+      dOff = writeLen(runLen - RUN_MASK, dest, dOff);
+    } else {
+      token = runLen << ML_BITS;
+    }
+
+    // copy literals
+    wildArraycopy(src, anchor, dest, dOff, runLen);
+    dOff += runLen;
+
+    // encode offset
+    final int matchDec = matchOff - matchRef;
+    dest[dOff++] = (byte) matchDec;
+    dest[dOff++] = (byte) (matchDec >>> 8);
+
+    // encode match len
+    matchLen -= 4;
+    if (dOff + (1 + LAST_LITERALS) + (matchLen >>> 8) > destEnd) {
+      throw new LZ4Exception("maxDestLen is too small");
+    }
+    if (matchLen >= ML_MASK) {
+      token |= ML_MASK;
+      dOff = writeLen(matchLen - RUN_MASK, dest, dOff);
+    } else {
+      token |= matchLen;
+    }
+
+    dest[tokenOff] = (byte) token;
+
+    return dOff;
+  }
+
+  static int lastLiterals(byte[] src, int sOff, int srcLen, byte[] dest, int dOff, int destEnd) {
+    final int runLen = srcLen;
+
+    if (dOff + runLen + 1 + (runLen + 255 - RUN_MASK) / 255 > destEnd) {
+      throw new LZ4Exception();
+    }
+
+    if (runLen >= RUN_MASK) {
+      dest[dOff++] = (byte) (RUN_MASK << ML_BITS);
+      dOff = writeLen(runLen - RUN_MASK, dest, dOff);
+    } else {
+      dest[dOff++] = (byte) (runLen << ML_BITS);
+    }
+    // copy literals
+    System.arraycopy(src, sOff, dest, dOff, runLen);
+    dOff += runLen;
+
+    return dOff;
+  }
+
+  static int writeLen(int len, byte[] dest, int dOff) {
+    while (len >= 0xFF) {
+      dest[dOff++] = (byte) 0xFF;
+      len -= 0xFF;
+    }
+    dest[dOff++] = (byte) len;
+    return dOff;
+  }
+
+  static class Match {
+    int start, ref, len;
+
+    void fix(int correction) {
+      start += correction;
+      ref += correction;
+      len -= correction;
+    }
+
+    int end() {
+      return start + len;
+    }
+  }
+
+  static void copyTo(Match m1, Match m2) {
+    m2.len = m1.len;
+    m2.start = m1.start;
+    m2.ref = m1.ref;
+  }
+
+}

--- a/disunity-core/src/main/java/info/ata4/util/lz4/LZ4Utils.java
+++ b/disunity-core/src/main/java/info/ata4/util/lz4/LZ4Utils.java
@@ -1,0 +1,74 @@
+/* Partial import of https://github.com/jpountz/lz4-java, Apache 2.0 licensed. */
+
+package info.ata4.util.lz4;
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static info.ata4.util.lz4.LZ4Constants.HASH_LOG;
+import static info.ata4.util.lz4.LZ4Constants.HASH_LOG_64K;
+import static info.ata4.util.lz4.LZ4Constants.HASH_LOG_HC;
+import static info.ata4.util.lz4.LZ4Constants.LAST_LITERALS;
+import static info.ata4.util.lz4.LZ4Constants.MIN_MATCH;
+import static info.ata4.util.lz4.LZ4Constants.ML_BITS;
+import static info.ata4.util.lz4.LZ4Constants.ML_MASK;
+import static info.ata4.util.lz4.LZ4Constants.RUN_MASK;
+
+enum LZ4Utils {
+  ;
+
+  private static final int MAX_INPUT_SIZE = 0x7E000000;
+
+  static int maxCompressedLength(int length) {
+    if (length < 0) {
+      throw new IllegalArgumentException("length must be >= 0, got " + length);
+    } else if (length >= MAX_INPUT_SIZE) {
+        throw new IllegalArgumentException("length must be < " + MAX_INPUT_SIZE);
+    }
+    return length + length / 255 + 16;
+  }
+
+  static int hash(int i) {
+    return (i * -1640531535) >>> ((MIN_MATCH * 8) - HASH_LOG);
+  }
+
+  static int hash64k(int i) {
+    return (i * -1640531535) >>> ((MIN_MATCH * 8) - HASH_LOG_64K);
+  }
+
+  static int hashHC(int i) {
+    return (i * -1640531535) >>> ((MIN_MATCH * 8) - HASH_LOG_HC);
+  }
+
+  static class Match {
+    int start, ref, len;
+
+    void fix(int correction) {
+      start += correction;
+      ref += correction;
+      len -= correction;
+    }
+
+    int end() {
+      return start + len;
+    }
+  }
+
+  static void copyTo(Match m1, Match m2) {
+    m2.len = m1.len;
+    m2.start = m1.start;
+    m2.ref = m1.ref;
+  }
+
+}

--- a/disunity-core/src/main/java/info/ata4/util/lz4/SafeUtils.java
+++ b/disunity-core/src/main/java/info/ata4/util/lz4/SafeUtils.java
@@ -1,0 +1,97 @@
+/* Partial import of https://github.com/jpountz/lz4-java, Apache 2.0 licensed. */
+
+package info.ata4.util.lz4;
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.nio.ByteOrder;
+
+public enum SafeUtils {
+  ;
+
+  public static void checkRange(byte[] buf, int off) {
+    if (off < 0 || off >= buf.length) {
+      throw new ArrayIndexOutOfBoundsException(off);
+    }
+  }
+
+  public static void checkRange(byte[] buf, int off, int len) {
+    checkLength(len);
+    if (len > 0) {
+      checkRange(buf, off);
+      checkRange(buf, off + len - 1);
+    }
+  }
+
+  public static void checkLength(int len) {
+    if (len < 0) {
+      throw new IllegalArgumentException("lengths must be >= 0");
+    }
+  }
+
+  public static byte readByte(byte[] buf, int i) {
+    return buf[i];
+  }
+
+  public static int readIntBE(byte[] buf, int i) {
+    return ((buf[i] & 0xFF) << 24) | ((buf[i+1] & 0xFF) << 16) | ((buf[i+2] & 0xFF) << 8) | (buf[i+3] & 0xFF);
+  }
+
+  public static int readIntLE(byte[] buf, int i) {
+    return (buf[i] & 0xFF) | ((buf[i+1] & 0xFF) << 8) | ((buf[i+2] & 0xFF) << 16) | ((buf[i+3] & 0xFF) << 24);
+  }
+
+  public static int readInt(byte[] buf, int i) {
+    if (Utils.NATIVE_BYTE_ORDER == ByteOrder.BIG_ENDIAN) {
+      return readIntBE(buf, i);
+    } else {
+      return readIntLE(buf, i);
+    }
+  }
+
+  public static long readLongLE(byte[] buf, int i) {
+    return (buf[i] & 0xFFL) | ((buf[i+1] & 0xFFL) << 8) | ((buf[i+2] & 0xFFL) << 16) | ((buf[i+3] & 0xFFL) << 24)
+         | ((buf[i+4] & 0xFFL) << 32) | ((buf[i+5] & 0xFFL) << 40) | ((buf[i+6] & 0xFFL) << 48) | ((buf[i+7] & 0xFFL) << 56);
+  }
+
+  public static void writeShortLE(byte[] buf, int off, int v) {
+    buf[off++] = (byte) v;
+    buf[off++] = (byte) (v >>> 8);
+  }
+
+  public static void writeInt(int[] buf, int off, int v) {
+    buf[off] = v;
+  }
+
+  public static int readInt(int[] buf, int off) {
+    return buf[off];
+  }
+
+  public static void writeByte(byte[] dest, int off, int i) {
+    dest[off] = (byte) i;
+  }
+
+  public static void writeShort(short[] buf, int off, int v) {
+    buf[off] = (short) v;
+  }
+
+  public static int readShortLE(byte[] buf, int i) {
+    return (buf[i] & 0xFF) | ((buf[i+1] & 0xFF) << 8);
+  }
+
+  public static int readShort(short[] buf, int off) {
+    return buf[off] & 0xFFFF;
+  }
+}

--- a/disunity-core/src/main/java/info/ata4/util/lz4/Utils.java
+++ b/disunity-core/src/main/java/info/ata4/util/lz4/Utils.java
@@ -1,0 +1,37 @@
+/* Partial import of https://github.com/jpountz/lz4-java, Apache 2.0 licensed. */
+
+package info.ata4.util.lz4;
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.nio.ByteOrder;
+
+public enum Utils {
+  ;
+
+  public static final ByteOrder NATIVE_BYTE_ORDER = ByteOrder.nativeOrder();
+
+  private static final boolean unalignedAccessAllowed;
+  static {
+    String arch = System.getProperty("os.arch");
+    unalignedAccessAllowed = arch.equals("i386") || arch.equals("x86")
+            || arch.equals("amd64") || arch.equals("x86_64");
+  }
+
+  public static boolean isUnalignedAccessAllowed() {
+    return unalignedAccessAllowed;
+  }
+
+}


### PR DESCRIPTION
As a first step towards issue #172. I don’t think this is really good enough to include as-is, but it appears to works and there's some design decisions needed that you should probably make on how to capture / structure the data and how to support LZ4.

The headlines for UnityFS are:

* most lengths and offsets are now 64-bit
* the data header is compressed with another scheme, LZ4
* there’s lots of new data I don't yet understand – not all stored and output on ‘info’ – and some old fields no longer populated
* I haven’t implemented packing, and I don’t have examples to test all code paths here.

For now I have shoe-horned the data into the existing structures, except I've added a new BundleInfoEntryFS since they are serialised differently. Might be worth considering whether to stick to a single set of structures or separate out new UnityFS classes?

To decompress LZ4 I have imported a subset of [lz4-java](https://github.com/jpountz/lz4-java), the native Java known-decompressed-size version. I did that rather than add a dependency because the original is likely overkill (a 200K jar, including optimised JNI versions for multiple platforms) and we’re only decompressing the data header with this. But that may be the correct solution long-term.
